### PR TITLE
Feature: Report options api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 subprojects {
     group = 'com.jaspersoft.android.sdk'
 
-    ext.clientModuleVersion = '1.10'
+    ext.clientModuleVersion = '1.11-SNAPSHOT'
     ext.clientModuleVersionCode = 9011000
 
     ext.androidMinSdkVersion = 9

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
@@ -24,6 +24,8 @@
 
 package com.jaspersoft.android.sdk.client;
 
+import android.net.Uri;
+
 import com.jaspersoft.android.sdk.client.oxm.ReportDescriptor;
 import com.jaspersoft.android.sdk.client.oxm.ResourceDescriptor;
 import com.jaspersoft.android.sdk.client.oxm.ResourceParameter;
@@ -43,6 +45,7 @@ import com.jaspersoft.android.sdk.client.oxm.report.ReportParameter;
 import com.jaspersoft.android.sdk.client.oxm.report.ReportParametersList;
 import com.jaspersoft.android.sdk.client.oxm.report.ReportStatusResponse;
 import com.jaspersoft.android.sdk.client.oxm.report.adapter.ExecutionRequestAdapter;
+import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOption;
 import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
 import com.jaspersoft.android.sdk.client.oxm.resource.ReportUnit;
 import com.jaspersoft.android.sdk.client.oxm.resource.ResourceLookup;
@@ -1349,6 +1352,36 @@ public class JsRestClient {
         String uri = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + resourceUri + REST_REPORT_OPTIONS_URI;
         return restTemplate.getForObject(uri, ReportOptionResponse.class);
     }
+
+    public ReportOption createReportOption(String resourceUri, String optionLabel,
+                                           Map<String, Set<String>> controlsValues,
+                                           boolean overwrite) {
+        String base = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + resourceUri + REST_REPORT_OPTIONS_URI;
+        Uri uri =  Uri.parse(base)
+                .buildUpon()
+                .appendQueryParameter("label", optionLabel)
+                .appendQueryParameter("overwrite", String.valueOf(overwrite))
+                .build();
+
+        if (dataType == DataType.JSON) {
+            return restTemplate.postForObject(uri.toString(), controlsValues, ReportOption.class);
+        } else if (dataType == DataType.XML) {
+            ReportParametersList list = new ReportParametersList();
+            for (Map.Entry<String, Set<String>> entry : controlsValues.entrySet()) {
+                String reportParamId = entry.getKey();
+                Set<String> reportParams = entry.getValue();
+
+                ReportParameter param = new ReportParameter();
+                param.setName(reportParamId);
+                param.setValues(reportParams);
+                list.getReportParameters().add(param);
+            }
+            return restTemplate.postForObject(uri.toString(), list, ReportOption.class);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     //---------------------------------------------------------------------
     // Helper methods
     //---------------------------------------------------------------------

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
@@ -1390,6 +1390,15 @@ public class JsRestClient {
         }
     }
 
+    public void deleteReportOption(String reportUnitUri, String optionId) {
+        String base = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + reportUnitUri + REST_REPORT_OPTIONS_URI;
+        Uri uri = Uri.parse(base)
+                .buildUpon()
+                .appendPath(optionId)
+                .build();
+        restTemplate.delete(URI.create(uri.toString()));
+    }
+
     //---------------------------------------------------------------------
     // Helper methods
     //---------------------------------------------------------------------

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
@@ -1348,6 +1348,11 @@ public class JsRestClient {
     // Report options API
     //---------------------------------------------------------------------
 
+    /**
+     * List all available report options for particular resources.
+     * @param reportUnitUri uri of report
+     * @return response that wraps report options collection
+     */
     public ReportOptionResponse getReportOptionsList(String reportUnitUri) {
         String uri = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + reportUnitUri + REST_REPORT_OPTIONS_URI;
 
@@ -1369,6 +1374,15 @@ public class JsRestClient {
         }
     }
 
+    /**
+     * Creates new report option.
+     *
+     * @param reportUnitUri uri of report we are going to use for new option
+     * @param optionLabel name of report option we are going to create
+     * @param controlsValues report parameters associated wtith report
+     * @param overwrite override values, if such report option exist
+     * @return newly created report option
+     */
     public ReportOption createReportOption(String reportUnitUri, String optionLabel,
                                            Map<String, Set<String>> controlsValues,
                                            boolean overwrite) {
@@ -1389,6 +1403,13 @@ public class JsRestClient {
         }
     }
 
+    /**
+     * Updating of report options with corresponding data set
+     *
+     * @param reportUnitUri uri of report we are going to use for particular option
+     * @param optionId id of report option we are going to update
+     * @param controlsValues new values we are going to pass
+     */
     public void updateReportOption(String reportUnitUri, String optionId, Map<String, Set<String>> controlsValues) {
         String base = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + reportUnitUri + REST_REPORT_OPTIONS_URI;
         Uri uri = Uri.parse(base)
@@ -1406,6 +1427,12 @@ public class JsRestClient {
         }
     }
 
+    /**
+     * API to delete report option
+     *
+     * @param reportUnitUri uri of report we are going to use for particular option
+     * @param optionId id of report option we are going to delete
+     */
     public void deleteReportOption(String reportUnitUri, String optionId) {
         String base = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + reportUnitUri + REST_REPORT_OPTIONS_URI;
         Uri uri = Uri.parse(base)

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/JsRestClient.java
@@ -43,6 +43,7 @@ import com.jaspersoft.android.sdk.client.oxm.report.ReportParameter;
 import com.jaspersoft.android.sdk.client.oxm.report.ReportParametersList;
 import com.jaspersoft.android.sdk.client.oxm.report.ReportStatusResponse;
 import com.jaspersoft.android.sdk.client.oxm.report.adapter.ExecutionRequestAdapter;
+import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
 import com.jaspersoft.android.sdk.client.oxm.resource.ReportUnit;
 import com.jaspersoft.android.sdk.client.oxm.resource.ResourceLookup;
 import com.jaspersoft.android.sdk.client.oxm.resource.ResourceLookupSearchCriteria;
@@ -101,6 +102,7 @@ public class JsRestClient {
     public static final String REST_RESOURCE_URI = "/resource";
     public static final String REST_RESOURCES_URI = "/resources";
     public static final String REST_REPORT_URI = "/report";
+    public static final String REST_REPORT_OPTIONS_URI = "/options";
     public static final String REST_REPORTS_URI = "/reports";
     public static final String REST_INPUT_CONTROLS_URI = "/inputControls";
     public static final String REST_VALUES_URI = "/values";
@@ -146,7 +148,7 @@ public class JsRestClient {
 
     public JsRestClient(RestTemplate restTemplate,
                         SimpleClientHttpRequestFactory factory) {
-       this(restTemplate, factory, DataType.XML);
+        this(restTemplate, factory, DataType.XML);
     }
 
     private JsRestClient(Builder builder) {
@@ -824,7 +826,7 @@ public class JsRestClient {
      * Sends request with porpose to fetch current export datum.
      *
      * @param executionId Identifies current id of running report.
-     * @param request we delegate to the restTemplate.
+     * @param request     we delegate to the restTemplate.
      * @return response with all exports datum associated with request.
      * @throws RestClientException
      */
@@ -879,7 +881,7 @@ public class JsRestClient {
     /**
      * Sends request for the current running export for the status check.
      *
-     * @param executionId Identifies current id of running report.
+     * @param executionId  Identifies current id of running report.
      * @param exportOutput Identifier which refers to current requested export.
      * @return response which expose current export status.
      */
@@ -890,7 +892,7 @@ public class JsRestClient {
     /**
      * Generates link for requesting report execution status.
      *
-     * @param executionId Identifies current id of running report.
+     * @param executionId  Identifies current id of running report.
      * @param exportOutput Identifier which refers to current requested export.
      * @return "{server url}/rest_v2/reportExecutions/{executionId}/exports/{exportOutput}/status"
      */
@@ -1100,7 +1102,7 @@ public class JsRestClient {
 
     /**
      * Deprecated due to the invalid selectedValues argument. Starting from 1.10 we are ignoring it.
-     *
+     * <p/>
      * Gets the list of input controls with specified IDs for the report with specified URI
      * and according to selected values.
      *
@@ -1131,7 +1133,7 @@ public class JsRestClient {
 
     /**
      * Deprecated due to the invalid selectedValues argument. Starting from 1.10 we are ignoring it.
-     *
+     * <p/>
      * Gets the list of input controls with specified IDs for the report with specified URI
      * and according to selected values.
      *
@@ -1330,7 +1332,7 @@ public class JsRestClient {
     /**
      * Returns thumbnail image or encoded image of the requested URI
      *
-     * @param resourceUri Uri of resource
+     * @param resourceUri    Uri of resource
      * @param defaultAllowed If true, a placeholder thumbnail will be provided when no thumbnail is available (default: false)
      * @return {serverUrl}/rest_v2/thumbnails/{resourceUri}?defaultAllowed={allowedFlag}
      */
@@ -1339,6 +1341,14 @@ public class JsRestClient {
                 + resourceUri + "?defaultAllowed=" + Boolean.toString(defaultAllowed);
     }
 
+    //---------------------------------------------------------------------
+    // Report options API
+    //---------------------------------------------------------------------
+
+    public ReportOptionResponse getReportOptionsList(String resourceUri) {
+        String uri = jsServerProfile.getServerUrl() + REST_SERVICES_V2_URI + REST_REPORTS_URI + resourceUri + REST_REPORT_OPTIONS_URI;
+        return restTemplate.getForObject(uri, ReportOptionResponse.class);
+    }
     //---------------------------------------------------------------------
     // Helper methods
     //---------------------------------------------------------------------

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/ReportParamsAdapter.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/ReportParamsAdapter.java
@@ -22,25 +22,34 @@
  * <http://www.gnu.org/licenses/lgpl>.
  */
 
-package com.jaspersoft.android.sdk.client.async.request;
+package com.jaspersoft.android.sdk.client;
 
-import com.jaspersoft.android.sdk.client.JsRestClient;
-import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
+import com.jaspersoft.android.sdk.client.oxm.report.ReportParameter;
+import com.jaspersoft.android.sdk.client.oxm.report.ReportParametersList;
+
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Tom Koptel
- * @since 1.11
+ * @since 2.0
  */
-public class ReportOptionsRequest extends BaseRequest<ReportOptionResponse> {
-    private final String mReportUri;
+enum ReportParamsAdapter {
+    INSTANCE;
 
-    public ReportOptionsRequest(JsRestClient jsRestClient, String reportUri) {
-        super(jsRestClient, ReportOptionResponse.class);
-        mReportUri = reportUri;
-    }
+    public ReportParametersList adapt(Map<String, Set<String>> controlsValues) {
+        ReportParametersList list = new ReportParametersList();
+        for (Map.Entry<String, Set<String>> entry : controlsValues.entrySet()) {
+            String reportParamId = entry.getKey();
+            Set<String> reportParams = entry.getValue();
 
-    @Override
-    public ReportOptionResponse loadDataFromNetwork() throws Exception {
-        return getJsRestClient().getReportOptionsList(mReportUri);
+            if (reportParamId != null && reportParams != null) {
+                ReportParameter param = new ReportParameter();
+                param.setName(reportParamId);
+                param.setValues(reportParams);
+                list.getReportParameters().add(param);
+            }
+        }
+        return list;
     }
 }

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/CreateReportOptionsRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/CreateReportOptionsRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of Jaspersoft Mobile for Android.
+ *
+ * Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.client.async.request;
+
+import com.jaspersoft.android.sdk.client.JsRestClient;
+import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOption;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Tom Koptel
+ * @since 1.11
+ */
+public class CreateReportOptionsRequest extends BaseRequest<ReportOption> {
+    private final String mReportUri;
+    private final String mOptionLabel;
+    private final Map<String, Set<String>> mControlsValue;
+    private final boolean mOverwrite;
+
+    public CreateReportOptionsRequest(JsRestClient jsRestClient, String reportUri,
+                                      String optionLabel, Map<String, Set<String>> controlsValues,
+                                      boolean overwrite) {
+        super(jsRestClient, ReportOption.class);
+        mReportUri = reportUri;
+        mOptionLabel = optionLabel;
+        mControlsValue = controlsValues;
+        mOverwrite = overwrite;
+    }
+    public CreateReportOptionsRequest(JsRestClient jsRestClient, String reportUri,
+                                      String optionLabel, Map<String, Set<String>> controlsValues) {
+        this(jsRestClient, reportUri, optionLabel, controlsValues, true);
+    }
+
+    @Override
+    public ReportOption loadDataFromNetwork() throws Exception {
+        return getJsRestClient().createReportOption(mReportUri, mOptionLabel, mControlsValue, mOverwrite);
+    }
+}

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/CreateReportOptionsRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/CreateReportOptionsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * Copyright ï¿½ 2015 TIBCO Software, Inc. All rights reserved.
  * http://community.jaspersoft.com/project/jaspermobile-android
  *
  * Unless you have purchased a commercial license agreement from Jaspersoft,
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
+ * Class that wraps {@link JsRestClient} instance in order to send create request of report option
+ *
  * @author Tom Koptel
  * @since 1.11
  */

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/DeleteReportOptionRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/DeleteReportOptionRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of Jaspersoft Mobile for Android.
+ *
+ * Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.client.async.request;
+
+import com.jaspersoft.android.sdk.client.JsRestClient;
+
+/**
+ * @author Tom Koptel
+ * @since 2.0
+ */
+public class DeleteReportOptionRequest extends BaseRequest<Void> {
+    private final String mReportUri;
+    private final String mOptionId;
+
+    public DeleteReportOptionRequest(JsRestClient jsRestClient,
+                                     String reportUri, String optionId) {
+        super(jsRestClient, Void.class);
+        mReportUri = reportUri;
+        mOptionId = optionId;
+    }
+
+
+    @Override
+    public Void loadDataFromNetwork() throws Exception {
+        getJsRestClient().deleteReportOption(mReportUri, mOptionId);
+        // We do not care about response
+        return null;
+    }
+}

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/DeleteReportOptionRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/DeleteReportOptionRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * Copyright ï¿½ 2015 TIBCO Software, Inc. All rights reserved.
  * http://community.jaspersoft.com/project/jaspermobile-android
  *
  * Unless you have purchased a commercial license agreement from Jaspersoft,
@@ -27,8 +27,10 @@ package com.jaspersoft.android.sdk.client.async.request;
 import com.jaspersoft.android.sdk.client.JsRestClient;
 
 /**
+ * Class that wraps {@link JsRestClient} instance in order to send delete request of report option
+ *
  * @author Tom Koptel
- * @since 2.0
+ * @since 1.11
  */
 public class DeleteReportOptionRequest extends BaseRequest<Void> {
     private final String mReportUri;

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/ReportOptionsRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/ReportOptionsRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of Jaspersoft Mobile for Android.
+ *
+ * Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.client.async.request;
+
+import com.jaspersoft.android.sdk.client.JsRestClient;
+import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
+
+/**
+ * @author Tom Koptel
+ * @since 1.11
+ */
+public class ReportOptionsRequest extends BaseRequest<ReportOptionResponse> {
+    private final String mReportUri;
+
+    public ReportOptionsRequest(JsRestClient jsRestClient, String reportUri) {
+        super(jsRestClient, ReportOptionResponse.class);
+        mReportUri = reportUri;
+    }
+    @Override
+    public ReportOptionResponse loadDataFromNetwork() throws Exception {
+        return getJsRestClient().getReportOptionsList(mReportUri);
+    }
+}

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/ReportOptionsRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/ReportOptionsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * Copyright ï¿½ 2015 TIBCO Software, Inc. All rights reserved.
  * http://community.jaspersoft.com/project/jaspermobile-android
  *
  * Unless you have purchased a commercial license agreement from Jaspersoft,
@@ -28,6 +28,8 @@ import com.jaspersoft.android.sdk.client.JsRestClient;
 import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
 
 /**
+ * Class that wraps {@link JsRestClient} instance in order to send get request of report option
+ *
  * @author Tom Koptel
  * @since 1.11
  */

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/UpdateReportOptionsRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/UpdateReportOptionsRequest.java
@@ -25,22 +25,31 @@
 package com.jaspersoft.android.sdk.client.async.request;
 
 import com.jaspersoft.android.sdk.client.JsRestClient;
-import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
+
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Tom Koptel
- * @since 1.11
+ * @since 2.0
  */
-public class ReportOptionsRequest extends BaseRequest<ReportOptionResponse> {
+public class UpdateReportOptionsRequest extends BaseRequest<Void> {
     private final String mReportUri;
+    private final String mOptionId;
+    private final Map<String, Set<String>> mControlsValue;
 
-    public ReportOptionsRequest(JsRestClient jsRestClient, String reportUri) {
-        super(jsRestClient, ReportOptionResponse.class);
+    public UpdateReportOptionsRequest(JsRestClient jsRestClient, String reportUri,
+                                      String optionId, Map<String, Set<String>> controlsValues) {
+        super(jsRestClient, Void.class);
         mReportUri = reportUri;
+        mOptionId = optionId;
+        mControlsValue = controlsValues;
     }
 
     @Override
-    public ReportOptionResponse loadDataFromNetwork() throws Exception {
-        return getJsRestClient().getReportOptionsList(mReportUri);
+    public Void loadDataFromNetwork() throws Exception {
+        getJsRestClient().updateReportOption(mReportUri, mOptionId, mControlsValue);
+        // We do not care about response
+        return null;
     }
 }

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/UpdateReportOptionsRequest.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/async/request/UpdateReportOptionsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * Copyright ï¿½ 2015 TIBCO Software, Inc. All rights reserved.
  * http://community.jaspersoft.com/project/jaspermobile-android
  *
  * Unless you have purchased a commercial license agreement from Jaspersoft,
@@ -30,8 +30,10 @@ import java.util.Map;
 import java.util.Set;
 
 /**
+ * Class that wraps {@link JsRestClient} instance in order to send update request of report option
+ *
  * @author Tom Koptel
- * @since 2.0
+ * @since 1.11
  */
 public class UpdateReportOptionsRequest extends BaseRequest<Void> {
     private final String mReportUri;

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/oxm/report/option/ReportOption.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/oxm/report/option/ReportOption.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of Jaspersoft Mobile for Android.
+ *
+ * Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.client.oxm.report.option;
+
+import android.support.annotation.NonNull;
+
+import com.google.gson.annotations.Expose;
+
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+/**
+ * @author Tom Koptel
+ * @since 1.11
+ */
+@Root(name="reportOptionsSummary")
+public class ReportOption {
+
+    @Expose
+    @Element
+    private String uri;
+    @Expose
+    @Element
+    private String id;
+    @Expose
+    @Element
+    private String label;
+
+    public ReportOption() {}
+
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    @NonNull
+    public String getLabel() {
+        return label;
+    }
+
+    @NonNull
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public String toString() {
+        return "ReportOption{" +
+                "id='" + id + '\'' +
+                ", uri='" + uri + '\'' +
+                ", label='" + label + '\'' +
+                '}';
+    }
+}
+

--- a/client/src/main/java/com/jaspersoft/android/sdk/client/oxm/report/option/ReportOptionResponse.java
+++ b/client/src/main/java/com/jaspersoft/android/sdk/client/oxm/report/option/ReportOptionResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of Jaspersoft Mobile for Android.
+ *
+ * Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.client.oxm.report.option;
+
+import android.support.annotation.NonNull;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Root;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Tom Koptel
+ * @since 1.11
+ */
+@Root(name = "reportOptionsSummaryList")
+public class ReportOptionResponse {
+
+    public ReportOptionResponse() {
+    }
+
+    @Expose
+    @SerializedName("reportOptionsSummary")
+    @ElementList(entry = "reportOptionsSummary", inline = true, empty = false)
+    private List<ReportOption> mOptions = new ArrayList<>();
+
+    @NonNull
+    public List<ReportOption> getOptions() {
+        return mOptions;
+    }
+}

--- a/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
+++ b/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
@@ -26,6 +26,7 @@ package com.jaspersoft.android.sdk.client.integration;
 
 import com.jaspersoft.android.sdk.client.JsRestClient;
 import com.jaspersoft.android.sdk.client.async.request.CreateReportOptionsRequest;
+import com.jaspersoft.android.sdk.client.async.request.DeleteReportOptionRequest;
 import com.jaspersoft.android.sdk.client.async.request.ReportOptionsRequest;
 import com.jaspersoft.android.sdk.client.async.request.UpdateReportOptionsRequest;
 import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOption;
@@ -96,10 +97,13 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
         CreateReportOptionsRequest createReportOptionsRequest =
                 new CreateReportOptionsRequest(jsRestClient, uri, "label", CONTROL_PARAMETERS);
 
-        ReportOption response = createReportOptionsRequest.loadDataFromNetwork();
-        assertThat(response, is(notNullValue()));
+        ReportOption reportOption = createReportOptionsRequest.loadDataFromNetwork();
+        assertThat(reportOption, is(notNullValue()));
 
-        UpdateReportOptionsRequest request = new UpdateReportOptionsRequest(jsRestClient, uri, response.getId(), CONTROL_PARAMETERS);
-        request.loadDataFromNetwork();
+        UpdateReportOptionsRequest updateRequest = new UpdateReportOptionsRequest(jsRestClient, uri, reportOption.getId(), CONTROL_PARAMETERS);
+        updateRequest.loadDataFromNetwork();
+
+        DeleteReportOptionRequest deleteRequest = new DeleteReportOptionRequest(jsRestClient, uri, reportOption.getId());
+        deleteRequest.loadDataFromNetwork();
     }
 }

--- a/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
+++ b/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
@@ -27,6 +27,7 @@ package com.jaspersoft.android.sdk.client.integration;
 import com.jaspersoft.android.sdk.client.JsRestClient;
 import com.jaspersoft.android.sdk.client.async.request.CreateReportOptionsRequest;
 import com.jaspersoft.android.sdk.client.async.request.ReportOptionsRequest;
+import com.jaspersoft.android.sdk.client.async.request.UpdateReportOptionsRequest;
 import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOption;
 import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
 import com.jaspersoft.android.sdk.client.util.RealHttpRule;
@@ -89,7 +90,7 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
     }
 
     @Test
-    public void requestShouldCreateReportOption() throws Exception {
+    public void shouldSupportCrudForReportOption() throws Exception {
         JsRestClient jsRestClient = getJsRestClient();
         String uri = getFactoryGirl().getResourceUri(jsRestClient);
         CreateReportOptionsRequest createReportOptionsRequest =
@@ -97,5 +98,8 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
 
         ReportOption response = createReportOptionsRequest.loadDataFromNetwork();
         assertThat(response, is(notNullValue()));
+
+        UpdateReportOptionsRequest request = new UpdateReportOptionsRequest(jsRestClient, uri, response.getId(), CONTROL_PARAMETERS);
+        request.loadDataFromNetwork();
     }
 }

--- a/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
+++ b/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
@@ -25,7 +25,9 @@
 package com.jaspersoft.android.sdk.client.integration;
 
 import com.jaspersoft.android.sdk.client.JsRestClient;
+import com.jaspersoft.android.sdk.client.async.request.CreateReportOptionsRequest;
 import com.jaspersoft.android.sdk.client.async.request.ReportOptionsRequest;
+import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOption;
 import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
 import com.jaspersoft.android.sdk.client.util.RealHttpRule;
 import com.jaspersoft.android.sdk.client.util.TargetDataType;
@@ -37,11 +39,16 @@ import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.notNullValue;
 
 /**
  * @author Tom Koptel
@@ -54,6 +61,13 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
     @Rule
     public RealHttpRule realHttpRule = new RealHttpRule();
 
+    public static final Map<String, Set<String>> CONTROL_PARAMETERS = new HashMap<>();
+    static {
+        Set<String> values = new HashSet<>();
+        values.add("19");
+        CONTROL_PARAMETERS.put("sales_fact_ALL__store_sales_2013_1", values);
+    }
+
     @ParameterizedRobolectricTestRunner.Parameters(name = "Data type = {2} Server version = {0} url = {1}")
     public static Collection<Object[]> data() {
         return ParametrizedTest.data(ReportOptionsRequestTest.class);
@@ -64,7 +78,7 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
     }
 
     @Test
-    public void requestShouldReportStatus() throws Exception {
+    public void requestShouldListOptions() throws Exception {
         JsRestClient jsRestClient = getJsRestClient();
         String uri = getFactoryGirl().getResourceUri(jsRestClient);
         ReportOptionsRequest runReportExecutionRequest = new ReportOptionsRequest(jsRestClient, uri);
@@ -72,5 +86,16 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
         ReportOptionResponse response = runReportExecutionRequest.loadDataFromNetwork();
 
         assertThat(response.getOptions(), is(not(empty())));
+    }
+
+    @Test
+    public void requestShouldCreateReportOption() throws Exception {
+        JsRestClient jsRestClient = getJsRestClient();
+        String uri = getFactoryGirl().getResourceUri(jsRestClient);
+        CreateReportOptionsRequest createReportOptionsRequest =
+                new CreateReportOptionsRequest(jsRestClient, uri, "label", CONTROL_PARAMETERS);
+
+        ReportOption response = createReportOptionsRequest.loadDataFromNetwork();
+        assertThat(response, is(notNullValue()));
     }
 }

--- a/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
+++ b/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
@@ -91,6 +91,17 @@ public class ReportOptionsRequestTest extends ParametrizedTest {
     }
 
     @Test
+    public void requestShouldListEmptyList() throws Exception {
+        JsRestClient jsRestClient = getJsRestClient();
+        String uri = "/public/Samples/Reports/AllAccounts";
+        ReportOptionsRequest runReportExecutionRequest = new ReportOptionsRequest(jsRestClient, uri);
+
+        ReportOptionResponse response = runReportExecutionRequest.loadDataFromNetwork();
+
+        assertThat(response.getOptions(), is(empty()));
+    }
+
+    @Test
     public void shouldSupportCrudForReportOption() throws Exception {
         JsRestClient jsRestClient = getJsRestClient();
         String uri = getFactoryGirl().getResourceUri(jsRestClient);

--- a/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
+++ b/client/src/test/java/com/jaspersoft/android/sdk/client/integration/ReportOptionsRequestTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of Jaspersoft Mobile for Android.
+ *
+ * Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.client.integration;
+
+import com.jaspersoft.android.sdk.client.JsRestClient;
+import com.jaspersoft.android.sdk.client.async.request.ReportOptionsRequest;
+import com.jaspersoft.android.sdk.client.oxm.report.option.ReportOptionResponse;
+import com.jaspersoft.android.sdk.client.util.RealHttpRule;
+import com.jaspersoft.android.sdk.client.util.TargetDataType;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+/**
+ * @author Tom Koptel
+ * @since 1.11
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+@TargetDataType(values = {"XML", "JSON"})
+public class ReportOptionsRequestTest extends ParametrizedTest {
+    @Rule
+    public RealHttpRule realHttpRule = new RealHttpRule();
+
+    @ParameterizedRobolectricTestRunner.Parameters(name = "Data type = {2} Server version = {0} url = {1}")
+    public static Collection<Object[]> data() {
+        return ParametrizedTest.data(ReportOptionsRequestTest.class);
+    }
+
+    public ReportOptionsRequestTest(String versionCode, String url, String dataType) {
+        super(versionCode, url, dataType);
+    }
+
+    @Test
+    public void requestShouldReportStatus() throws Exception {
+        JsRestClient jsRestClient = getJsRestClient();
+        String uri = getFactoryGirl().getResourceUri(jsRestClient);
+        ReportOptionsRequest runReportExecutionRequest = new ReportOptionsRequest(jsRestClient, uri);
+
+        ReportOptionResponse response = runReportExecutionRequest.loadDataFromNetwork();
+
+        assertThat(response.getOptions(), is(not(empty())));
+    }
+}


### PR DESCRIPTION
Add support for Report options API.

``` java
public static final Map<String, Set<String>> CONTROL_PARAMETERS = new HashMap<>();
static {
    Set<String> values = new HashSet<>();
    values.add("19");
    CONTROL_PARAMETERS.put("sales_fact_ALL__store_sales_2013_1", values);
}

// List options
ReportOptionsRequest runReportExecutionRequest = new ReportOptionsRequest(jsRestClient, uri);
ReportOptionResponse response = runReportExecutionRequest.loadDataFromNetwork();

// Create option
ReportOption reportOption = createReportOptionsRequest.loadDataFromNetwork();
assertThat(reportOption, is(notNullValue()));

// Update option
UpdateReportOptionsRequest updateRequest = new UpdateReportOptionsRequest(jsRestClient, uri, reportOption.getId(), CONTROL_PARAMETERS);
updateRequest.loadDataFromNetwork();

// Delete option
DeleteReportOptionRequest deleteRequest = new DeleteReportOptionRequest(jsRestClient, uri, reportOption.getId());
deleteRequest.loadDataFromNetwork();
```
