### PR TITLE
Add support for fetching report resource metadata

### DIFF
--- a/core/src/main/java/com/jaspersoft/android/sdk/network/entity/resource/ReportLookup.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/entity/resource/ReportLookup.java
@@ -42,7 +42,7 @@ public class ReportLookup extends ResourceLookup {
         return "reportUnit";
     }
 
-    public boolean isAlwaysPromptControls() {
+    public boolean alwaysPromptControls() {
         return alwaysPromptControls;
     }
 

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/data/report/ReportResource.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/data/report/ReportResource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from TIBCO Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of TIBCO Jaspersoft Mobile for Android.
+ *
+ * TIBCO Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TIBCO Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TIBCO Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.service.data.report;
+
+import com.jaspersoft.android.sdk.service.data.repository.Resource;
+import com.jaspersoft.android.sdk.service.data.repository.ResourceType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Date;
+
+/**
+ * @author Tom Koptel
+ * @since 2.0
+ */
+public class ReportResource extends Resource {
+    private final boolean mAlwaysPrompt;
+
+    public ReportResource(@Nullable Date creationDate,
+                          @Nullable Date updateDate,
+                          @NotNull ResourceType resourceType,
+                          @NotNull String label,
+                          @NotNull String description,
+                          boolean alwaysPrompt) {
+        super(creationDate, updateDate, resourceType, label, description);
+        mAlwaysPrompt = alwaysPrompt;
+    }
+
+    public boolean alwaysPromptControls() {
+        return mAlwaysPrompt;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ReportResource that = (ReportResource) o;
+
+        if (mAlwaysPrompt != that.mAlwaysPrompt) return false;
+
+        return true;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (mAlwaysPrompt ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ReportResource{" +
+                "mCreationDate=" + getCreationDate() +
+                ", mUpdateDate=" + getUpdateDate() +
+                ", mResourceType=" + getResourceType() +
+                ", mLabel='" + getLabel() + '\'' +
+                ", mDescription='" + getDescription() + '\'' +
+                ", mAlwaysPrompt=" + mAlwaysPrompt +
+                '}';
+    }
+}

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/data/repository/Resource.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/data/repository/Resource.java
@@ -36,21 +36,31 @@ import java.util.Date;
  */
 public class Resource {
     @Nullable
-    private Date mCreationDate;
+    private final Date mCreationDate;
     @Nullable
-    private Date mUpdateDate;
+    private final Date mUpdateDate;
+    @NotNull
+    private final ResourceType mResourceType;
+    @NotNull
+    private final String mLabel;
+    @NotNull
+    private final String mDescription;
 
-    private ResourceType mResourceType;
-    private String mLabel;
-    private String mDescription;
+    public Resource(@Nullable Date creationDate,
+                    @Nullable Date updateDate,
+                    @NotNull ResourceType resourceType,
+                    @NotNull String label,
+                    @NotNull String description) {
+        mCreationDate = creationDate;
+        mUpdateDate = updateDate;
+        mResourceType = resourceType;
+        mLabel = label;
+        mDescription = description;
+    }
 
     @Nullable
     public Date getCreationDate() {
         return mCreationDate;
-    }
-
-    public void setCreationDate(@Nullable Date creationDate) {
-        mCreationDate = creationDate;
     }
 
     @Nullable
@@ -58,17 +68,9 @@ public class Resource {
         return mUpdateDate;
     }
 
-    public void setUpdateDate(@Nullable Date updateDate) {
-        mUpdateDate = updateDate;
-    }
-
     @NotNull
     public ResourceType getResourceType() {
         return mResourceType;
-    }
-
-    public void setResourceType(@NotNull ResourceType resourceType) {
-        mResourceType = resourceType;
     }
 
     @NotNull
@@ -76,16 +78,48 @@ public class Resource {
         return mLabel;
     }
 
-    public void setLabel(@NotNull String label) {
-        mLabel = label;
-    }
-
     @NotNull
     public String getDescription() {
         return mDescription;
     }
 
-    public void setDescription(@NotNull String description) {
-        mDescription = description;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Resource resource = (Resource) o;
+
+        if (mCreationDate != null ? !mCreationDate.equals(resource.mCreationDate) : resource.mCreationDate != null)
+            return false;
+        if (mDescription != null ? !mDescription.equals(resource.mDescription) : resource.mDescription != null)
+            return false;
+        if (mLabel != null ? !mLabel.equals(resource.mLabel) : resource.mLabel != null) return false;
+        if (mResourceType != resource.mResourceType) return false;
+        if (mUpdateDate != null ? !mUpdateDate.equals(resource.mUpdateDate) : resource.mUpdateDate != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mCreationDate != null ? mCreationDate.hashCode() : 0;
+        result = 31 * result + (mUpdateDate != null ? mUpdateDate.hashCode() : 0);
+        result = 31 * result + (mResourceType != null ? mResourceType.hashCode() : 0);
+        result = 31 * result + (mLabel != null ? mLabel.hashCode() : 0);
+        result = 31 * result + (mDescription != null ? mDescription.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Resource{" +
+                "mCreationDate=" + mCreationDate +
+                ", mUpdateDate=" + mUpdateDate +
+                ", mResourceType=" + mResourceType +
+                ", mLabel='" + mLabel + '\'' +
+                ", mDescription='" + mDescription + '\'' +
+                '}';
     }
 }

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/repository/ProxyRepositoryService.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/repository/ProxyRepositoryService.java
@@ -24,6 +24,10 @@
 
 package com.jaspersoft.android.sdk.service.repository;
 
+import com.jaspersoft.android.sdk.network.entity.resource.ReportLookup;
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
+import com.jaspersoft.android.sdk.service.exception.ServiceException;
+import com.jaspersoft.android.sdk.service.internal.Preconditions;
 import com.jaspersoft.android.sdk.service.internal.info.InfoCacheManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,11 +39,16 @@ import org.jetbrains.annotations.TestOnly;
  */
 final class ProxyRepositoryService extends RepositoryService {
     private final SearchUseCase mSearchUseCase;
+    private final RepositoryUseCase mRepositoryUseCase;
     private final InfoCacheManager mInfoCacheManager;
 
     @TestOnly
-    ProxyRepositoryService(SearchUseCase searchUseCase, InfoCacheManager infoCacheManager) {
+    ProxyRepositoryService(
+            SearchUseCase searchUseCase,
+            RepositoryUseCase repositoryUseCase,
+            InfoCacheManager infoCacheManager) {
         mSearchUseCase = searchUseCase;
+        mRepositoryUseCase = repositoryUseCase;
         mInfoCacheManager = infoCacheManager;
     }
 
@@ -53,5 +62,12 @@ final class ProxyRepositoryService extends RepositoryService {
         InternalCriteria internalCriteria = InternalCriteria.from(criteria);
         SearchTaskFactory searchTaskFactory = new SearchTaskFactory(internalCriteria, mSearchUseCase, mInfoCacheManager);
         return new SearchTaskProxy(searchTaskFactory);
+    }
+
+    @NotNull
+    @Override
+    public ReportResource fetchReportDetails(@NotNull String reportUri) throws ServiceException {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        return mRepositoryUseCase.getReportDetails(reportUri);
     }
 }

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/repository/ReportResourceMapper.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/repository/ReportResourceMapper.java
@@ -1,61 +1,44 @@
 /*
- * Copyright (C) 2015 TIBCO Jaspersoft Corporation. All rights reserved.
- * http://community.jaspersoft.com/project/mobile-sdk-android
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
  *
  * Unless you have purchased a commercial license agreement from TIBCO Jaspersoft,
  * the following license terms apply:
  *
- * This program is part of TIBCO Jaspersoft Mobile SDK for Android.
+ * This program is part of TIBCO Jaspersoft Mobile for Android.
  *
- * TIBCO Jaspersoft Mobile SDK is free software: you can redistribute it and/or modify
+ * TIBCO Jaspersoft Mobile is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * TIBCO Jaspersoft Mobile SDK is distributed in the hope that it will be useful,
+ * TIBCO Jaspersoft Mobile is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with TIBCO Jaspersoft Mobile SDK for Android. If not, see
+ * along with TIBCO Jaspersoft Mobile for Android. If not, see
  * <http://www.gnu.org/licenses/lgpl>.
  */
 
 package com.jaspersoft.android.sdk.service.repository;
 
-
-import com.jaspersoft.android.sdk.network.entity.resource.ResourceLookup;
-import com.jaspersoft.android.sdk.service.data.repository.Resource;
+import com.jaspersoft.android.sdk.network.entity.resource.ReportLookup;
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
 import com.jaspersoft.android.sdk.service.data.repository.ResourceType;
-import org.jetbrains.annotations.NotNull;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author Tom Koptel
  * @since 2.0
  */
-class ResourceMapper {
+class ReportResourceMapper {
 
-    @NotNull
-    public List<Resource> transform(Collection<ResourceLookup> resources, SimpleDateFormat dateTimeFormat) {
-        List<Resource> result = new LinkedList<>();
-        for (ResourceLookup lookup : resources) {
-            if (lookup != null) {
-                result.add(transform(lookup, dateTimeFormat));
-            }
-        }
-        return result;
-    }
-
-    @NotNull
-    public Resource transform(ResourceLookup lookup, SimpleDateFormat dateTimeFormat) {
+    public ReportResource transform(ReportLookup lookup, SimpleDateFormat dateTimeFormat) {
         Date creationDate;
         Date updateDate;
 
@@ -71,6 +54,11 @@ class ResourceMapper {
         if (type != null) {
             resourceType = ResourceType.defaultParser().parse(type);
         }
-        return new Resource(creationDate, updateDate, resourceType, lookup.getLabel(), lookup.getDescription());
+        return new ReportResource(creationDate,
+                updateDate,
+                resourceType,
+                lookup.getLabel(),
+                lookup.getDescription(),
+                lookup.alwaysPromptControls());
     }
 }

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/repository/RepositoryService.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/repository/RepositoryService.java
@@ -26,6 +26,8 @@ package com.jaspersoft.android.sdk.service.repository;
 
 import com.jaspersoft.android.sdk.network.AuthorizedClient;
 import com.jaspersoft.android.sdk.network.RepositoryRestApi;
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
+import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import com.jaspersoft.android.sdk.service.internal.*;
 import com.jaspersoft.android.sdk.service.internal.info.InMemoryInfoCache;
 import com.jaspersoft.android.sdk.service.internal.info.InfoCache;
@@ -40,6 +42,9 @@ import org.jetbrains.annotations.Nullable;
 public abstract class RepositoryService {
     @NotNull
     public abstract SearchTask search(@Nullable SearchCriteria criteria);
+
+    @NotNull
+    public abstract ReportResource fetchReportDetails(@NotNull String reportUri) throws ServiceException;
 
     @NotNull
     public static RepositoryService newService(@NotNull AuthorizedClient client) {
@@ -58,6 +63,9 @@ public abstract class RepositoryService {
                 cacheManager,
                 callExecutor
         );
-        return new ProxyRepositoryService(searchUseCase, cacheManager);
+        ReportResourceMapper reportResourceMapper = new ReportResourceMapper();
+        RepositoryUseCase repositoryUseCase = new RepositoryUseCase(defaultExMapper,
+                repositoryRestApi, reportResourceMapper, cacheManager);
+        return new ProxyRepositoryService(searchUseCase, repositoryUseCase, cacheManager);
     }
 }

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/repository/RepositoryUseCase.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/repository/RepositoryUseCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from TIBCO Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of TIBCO Jaspersoft Mobile for Android.
+ *
+ * TIBCO Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TIBCO Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TIBCO Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.service.repository;
+
+import com.jaspersoft.android.sdk.network.HttpException;
+import com.jaspersoft.android.sdk.network.RepositoryRestApi;
+import com.jaspersoft.android.sdk.network.entity.resource.ReportLookup;
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
+import com.jaspersoft.android.sdk.service.data.server.ServerInfo;
+import com.jaspersoft.android.sdk.service.exception.ServiceException;
+import com.jaspersoft.android.sdk.service.internal.ServiceExceptionMapper;
+import com.jaspersoft.android.sdk.service.internal.info.InfoCacheManager;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
+/**
+ * @author Tom Koptel
+ * @since 2.0
+ */
+class RepositoryUseCase {
+    private final ServiceExceptionMapper mServiceExceptionMapper;
+    private final RepositoryRestApi mRepositoryRestApi;
+    private final ReportResourceMapper mReportResourceMapper;
+    private final InfoCacheManager mInfoCacheManager;
+
+    RepositoryUseCase(ServiceExceptionMapper serviceExceptionMapper,
+                      RepositoryRestApi repositoryRestApi,
+                      ReportResourceMapper reportResourceMapper,
+                      InfoCacheManager infoCacheManager) {
+        mServiceExceptionMapper = serviceExceptionMapper;
+        mRepositoryRestApi = repositoryRestApi;
+        mReportResourceMapper = reportResourceMapper;
+        mInfoCacheManager = infoCacheManager;
+    }
+
+    public ReportResource getReportDetails(String reportUri) throws ServiceException {
+        try {
+            ServerInfo info = mInfoCacheManager.getInfo();
+            SimpleDateFormat datetimeFormatPattern = info.getDatetimeFormatPattern();
+            ReportLookup reportLookup = mRepositoryRestApi.requestReportResource(reportUri);
+            return mReportResourceMapper.transform(reportLookup, datetimeFormatPattern);
+        } catch (HttpException e) {
+            throw mServiceExceptionMapper.transform(e);
+        } catch (IOException e) {
+            throw mServiceExceptionMapper.transform(e);
+        }
+    }
+}

--- a/core/src/test/java/com/jaspersoft/android/sdk/service/repository/ProxyRepositoryServiceTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/service/repository/ProxyRepositoryServiceTest.java
@@ -35,26 +35,35 @@ import org.mockito.MockitoAnnotations;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.rules.ExpectedException.none;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Tom Koptel
  * @since 2.0
  */
 public class ProxyRepositoryServiceTest {
+    private static final String REPORT_URI = "/my/uri";
+
     @Mock
-    SearchUseCase mCase;
+    SearchUseCase mSearchCase;
+    @Mock
+    RepositoryUseCase mRepositoryUseCase;
     @Mock
     InfoCacheManager mInfoCacheManager;
+
+    @Rule
+    public ExpectedException expected = none();
 
     private ProxyRepositoryService objectUnderTest;
 
     @Rule
-    public ExpectedException mExpectedException = ExpectedException.none();
+    public ExpectedException mExpectedException = none();
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        objectUnderTest = new ProxyRepositoryService(mCase, mInfoCacheManager);
+        objectUnderTest = new ProxyRepositoryService(mSearchCase, mRepositoryUseCase, mInfoCacheManager);
     }
 
     @Test
@@ -67,5 +76,18 @@ public class ProxyRepositoryServiceTest {
     public void should_accept_null_criteria() {
         SearchTask searchTask = objectUnderTest.search(null);
         assertThat(searchTask, is(notNullValue()));
+    }
+
+    @Test
+    public void fetch_should_delegate_request_on_usecase() throws Exception {
+        objectUnderTest.fetchReportDetails(REPORT_URI);
+        verify(mRepositoryUseCase).getReportDetails(REPORT_URI);
+    }
+
+    @Test
+    public void fetch_report_details_fails_with_null_uri() throws Exception {
+        expected.expectMessage("Report uri should not be null");
+        expected.expect(NullPointerException.class);
+        objectUnderTest.fetchReportDetails(null);
     }
 }

--- a/core/src/test/java/com/jaspersoft/android/sdk/service/repository/ReportResourceMapperTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/service/repository/ReportResourceMapperTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from TIBCO Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of TIBCO Jaspersoft Mobile for Android.
+ *
+ * TIBCO Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TIBCO Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TIBCO Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.service.repository;
+
+import com.jaspersoft.android.sdk.network.entity.resource.ReportLookup;
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
+import com.jaspersoft.android.sdk.service.data.repository.ResourceType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ReportResourceMapperTest {
+    public static final String FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    public static final SimpleDateFormat DATE_FORMAT =
+            new SimpleDateFormat(FORMAT_PATTERN, Locale.getDefault());
+
+    @Mock
+    ReportLookup mReportLookup;
+    private ReportResourceMapper mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        mapper = new ReportResourceMapper();
+
+        when(mReportLookup.getCreationDate()).thenReturn("2013-10-03 16:32:05");
+        when(mReportLookup.getUpdateDate()).thenReturn("2013-11-03 16:32:05");
+        when(mReportLookup.getResourceType()).thenReturn("reportUnit");
+        when(mReportLookup.getDescription()).thenReturn("description");
+        when(mReportLookup.getLabel()).thenReturn("label");
+        when(mReportLookup.alwaysPromptControls()).thenReturn(false);
+    }
+
+    @Test
+    public void testTransform() throws Exception {
+        long creationTime = DATE_FORMAT.parse("2013-10-03 16:32:05").getTime();
+        long updateTime = DATE_FORMAT.parse("2013-11-03 16:32:05").getTime();
+
+        ReportResource resource = mapper.transform(mReportLookup, DATE_FORMAT);
+        assertThat(resource.getCreationDate().getTime(), is(creationTime));
+        assertThat(resource.getUpdateDate().getTime(), is(updateTime));
+        assertThat(resource.getDescription(), is("description"));
+        assertThat(resource.getLabel(), is("label"));
+        assertThat(resource.getResourceType(), is(ResourceType.reportUnit));
+        assertThat(resource.getResourceType(), is(ResourceType.reportUnit));
+        assertThat(resource.alwaysPromptControls(), is(false));
+
+    }
+}

--- a/core/src/test/java/com/jaspersoft/android/sdk/service/repository/RepositoryUseCaseTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/service/repository/RepositoryUseCaseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 TIBCO Software, Inc. All rights reserved.
+ * http://community.jaspersoft.com/project/jaspermobile-android
+ *
+ * Unless you have purchased a commercial license agreement from TIBCO Jaspersoft,
+ * the following license terms apply:
+ *
+ * This program is part of TIBCO Jaspersoft Mobile for Android.
+ *
+ * TIBCO Jaspersoft Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TIBCO Jaspersoft Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TIBCO Jaspersoft Mobile for Android. If not, see
+ * <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package com.jaspersoft.android.sdk.service.repository;
+
+import com.jaspersoft.android.sdk.network.RepositoryRestApi;
+import com.jaspersoft.android.sdk.network.entity.resource.ReportLookup;
+import com.jaspersoft.android.sdk.service.data.server.ServerInfo;
+import com.jaspersoft.android.sdk.service.internal.ServiceExceptionMapper;
+import com.jaspersoft.android.sdk.service.internal.info.InfoCacheManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.text.SimpleDateFormat;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class RepositoryUseCaseTest {
+    private static final String REPORT_URI = "/my/uri";
+
+    @Mock
+    ServiceExceptionMapper mServiceExceptionMapper;
+    @Mock
+    RepositoryRestApi mRepositoryRestApi;
+    @Mock
+    ReportResourceMapper reportResourceMapper;
+    @Mock
+    InfoCacheManager infoCacheManager;
+    @Mock
+    ServerInfo mServerInfo;
+
+    private RepositoryUseCase useCase;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        useCase = new RepositoryUseCase(
+                mServiceExceptionMapper,
+                mRepositoryRestApi,
+                reportResourceMapper,
+                infoCacheManager);
+    }
+
+    @Test
+    public void testGetReportDetails() throws Exception {
+        when(infoCacheManager.getInfo()).thenReturn(mServerInfo);
+
+        useCase.getReportDetails(REPORT_URI);
+
+        verify(infoCacheManager).getInfo();
+        verify(reportResourceMapper).transform(any(ReportLookup.class), any(SimpleDateFormat.class));
+        verify(mRepositoryRestApi).requestReportResource(REPORT_URI);
+    }
+}

--- a/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/repository/RxRepositoryService.java
+++ b/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/repository/RxRepositoryService.java
@@ -25,6 +25,7 @@
 package com.jaspersoft.android.sdk.service.rx.repository;
 
 import com.jaspersoft.android.sdk.network.AuthorizedClient;
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
 import com.jaspersoft.android.sdk.service.internal.Preconditions;
 import com.jaspersoft.android.sdk.service.repository.RepositoryService;
 import com.jaspersoft.android.sdk.service.repository.SearchCriteria;
@@ -40,6 +41,8 @@ import rx.Observable;
 public abstract class RxRepositoryService {
     @NotNull
     public abstract Observable<RxSearchTask> search(@Nullable SearchCriteria criteria);
+    @NotNull
+    public abstract Observable<ReportResource> fetchReportDetails(@NotNull String reportUri);
 
     @NotNull
     public static RxRepositoryService newService(@NotNull AuthorizedClient authorizedClient) {

--- a/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/repository/RxRepositoryServiceImpl.java
+++ b/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/repository/RxRepositoryServiceImpl.java
@@ -24,6 +24,8 @@
 
 package com.jaspersoft.android.sdk.service.rx.repository;
 
+import com.jaspersoft.android.sdk.service.data.report.ReportResource;
+import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import com.jaspersoft.android.sdk.service.repository.RepositoryService;
 import com.jaspersoft.android.sdk.service.repository.SearchCriteria;
 import com.jaspersoft.android.sdk.service.repository.SearchTask;
@@ -31,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 import rx.Observable;
+import rx.functions.Func0;
 
 /**
  * @author Tom Koptel
@@ -50,5 +53,21 @@ final class RxRepositoryServiceImpl extends RxRepositoryService {
         SearchTask searchTask = mSyncDelegate.search(criteria);
         RxSearchTask rxSearchTask = new RxSearchTaskImpl(searchTask);
         return Observable.just(rxSearchTask);
+    }
+
+    @NotNull
+    @Override
+    public Observable<ReportResource> fetchReportDetails(@NotNull final String reportUri) {
+        return Observable.defer(new Func0<Observable<ReportResource>>() {
+            @Override
+            public Observable<ReportResource> call() {
+                try {
+                    ReportResource reportResource = mSyncDelegate.fetchReportDetails(reportUri);
+                    return Observable.just(reportResource);
+                } catch (ServiceException e) {
+                    return Observable.error(e);
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
``` java
AuthorizedClient client;
RepositoryService service = RepositoryService.newService(client);
try {
  service.fetchReportDetails("my/uri");
} catch (ServiceException e) {
  e.printStackTrace();
}

RxRepositoryService rxServcie = RxRepositoryService.newService(client);
rxServcie.fetchReportDetails("my/uri").subscribe(); 
```
