### PR TITLE
Add support for report parameters CRUD in ReportService

### DIFF
--- a/core/src/main/java/com/jaspersoft/android/sdk/network/InputControlRestApiImpl.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/InputControlRestApiImpl.java
@@ -81,13 +81,7 @@ final class InputControlRestApiImpl implements InputControlRestApi {
         Utils.checkNotNull(reportUri, "Report URI should not be null");
         Utils.checkNotNull(parameters, "Parameters should not be null");
 
-        int capacity = parameters.size();
-        Map<String, Set<String>> params = new HashMap<>(capacity);
-        for (int i = 0; i < capacity; i++) {
-            ReportParameter param = parameters.get(i);
-            params.put(param.getName(), param.getValue());
-        }
-
+        Map<String, Set<String>> params = ReportParamsMapper.INSTANCE.toMap(parameters);
         String ids = Utils.joinString(";", params.keySet());
         Call<InputControlStateCollection> call = mRestApi.requestInputControlsValues(reportUri,
                 ids, params, freshData);

--- a/core/src/main/java/com/jaspersoft/android/sdk/network/ReportOptionRestApi.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/ReportOptionRestApi.java
@@ -24,12 +24,12 @@
 
 package com.jaspersoft.android.sdk.network;
 
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
 import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -44,12 +44,12 @@ public interface ReportOptionRestApi {
     @NotNull
     ReportOption createReportOption(@NotNull String reportUnitUri,
                                     @NotNull String optionLabel,
-                                    @NotNull Map<String, Set<String>> controlsValues,
+                                    @NotNull List<ReportParameter> parameters,
                                     boolean overwrite) throws HttpException, IOException;
 
     void updateReportOption(@NotNull String reportUnitUri,
                             @NotNull String optionId,
-                            @NotNull Map<String, Set<String>> controlsValues) throws HttpException, IOException;
+                            @NotNull List<ReportParameter> parameters) throws HttpException, IOException;
 
     void deleteReportOption(@NotNull String reportUnitUri,
                             @NotNull String optionId) throws HttpException, IOException;

--- a/core/src/main/java/com/jaspersoft/android/sdk/network/ReportOptionRestApiImpl.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/ReportOptionRestApiImpl.java
@@ -25,6 +25,7 @@
 package com.jaspersoft.android.sdk.network;
 
 import com.google.gson.JsonSyntaxException;
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
 import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.network.entity.report.option.ReportOptionSet;
 import com.squareup.okhttp.Response;
@@ -36,6 +37,7 @@ import retrofit.http.*;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -75,32 +77,32 @@ final class ReportOptionRestApiImpl implements ReportOptionRestApi {
     public ReportOption createReportOption(
                                            @Nullable String reportUnitUri,
                                            @Nullable String optionLabel,
-                                           @Nullable Map<String, Set<String>> controlsValues,
+                                           @Nullable List<ReportParameter> parameters,
                                            boolean overwrite) throws IOException, HttpException {
         Utils.checkNotNull(reportUnitUri, "Report uri should not be null");
         Utils.checkNotNull(optionLabel, "Option label should not be null");
-        Utils.checkNotNull(controlsValues, "Controls values should not be null");
+        Utils.checkNotNull(parameters, "Parameters values should not be null");
 
+        Map<String, Set<String>> controlsValues = ReportParamsMapper.INSTANCE.toMap(parameters);
         Call<ReportOption> call = mRestApi.createReportOption(reportUnitUri, optionLabel, controlsValues, overwrite);
         return CallWrapper.wrap(call).body();
     }
 
     @Override
-    public void updateReportOption(
-                                   @Nullable String reportUnitUri,
+    public void updateReportOption(@Nullable String reportUnitUri,
                                    @Nullable String optionId,
-                                   @Nullable Map<String, Set<String>> controlsValues) throws IOException, HttpException {
+                                   @Nullable List<ReportParameter> parameters) throws IOException, HttpException {
         Utils.checkNotNull(reportUnitUri, "Report uri should not be null");
         Utils.checkNotNull(optionId, "Option id should not be null");
-        Utils.checkNotNull(controlsValues, "Controls values should not be null");
+        Utils.checkNotNull(parameters, "Parameters values should not be null");
 
+        Map<String, Set<String>> controlsValues = ReportParamsMapper.INSTANCE.toMap(parameters);
         Call<Response> call = mRestApi.updateReportOption(reportUnitUri, optionId, controlsValues);
         CallWrapper.wrap(call).body();
     }
 
     @Override
-    public void deleteReportOption(
-                                   @Nullable String reportUnitUri,
+    public void deleteReportOption(@Nullable String reportUnitUri,
                                    @Nullable String optionId) throws IOException, HttpException {
         Utils.checkNotNull(reportUnitUri, "Report uri should not be null");
         Utils.checkNotNull(optionId, "Option id should not be null");

--- a/core/src/main/java/com/jaspersoft/android/sdk/network/ReportParamsMapper.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/ReportParamsMapper.java
@@ -1,0 +1,26 @@
+package com.jaspersoft.android.sdk.network;
+
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Tom Koptel
+ * @since 2.0
+ */
+enum ReportParamsMapper {
+    INSTANCE;
+
+    public Map<String, Set<String>> toMap(List<ReportParameter> parameters) {
+        int capacity = parameters.size();
+        Map<String, Set<String>> params = new HashMap<>(capacity);
+        for (int i = 0; i < capacity; i++) {
+            ReportParameter param = parameters.get(i);
+            params.put(param.getName(), param.getValue());
+        }
+        return params;
+    }
+}

--- a/core/src/main/java/com/jaspersoft/android/sdk/network/entity/report/option/ReportOption.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/entity/report/option/ReportOption.java
@@ -25,7 +25,6 @@
 package com.jaspersoft.android.sdk.network.entity.report.option;
 
 import com.google.gson.annotations.Expose;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -63,17 +62,18 @@ public final class ReportOption {
 
         ReportOption that = (ReportOption) o;
 
-        if (!uri.equals(that.uri)) return false;
-        if (!id.equals(that.id)) return false;
-        return label.equals(that.label);
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (label != null ? !label.equals(that.label) : that.label != null) return false;
+        if (uri != null ? !uri.equals(that.uri) : that.uri != null) return false;
 
+        return true;
     }
 
     @Override
     public int hashCode() {
-        int result = uri.hashCode();
-        result = 31 * result + id.hashCode();
-        result = 31 * result + label.hashCode();
+        int result = uri != null ? uri.hashCode() : 0;
+        result = 31 * result + (id != null ? id.hashCode() : 0);
+        result = 31 * result + (label != null ? label.hashCode() : 0);
         return result;
     }
 

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/AbstractReportService.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/AbstractReportService.java
@@ -28,10 +28,12 @@ import com.jaspersoft.android.sdk.network.entity.control.InputControl;
 import com.jaspersoft.android.sdk.network.entity.control.InputControlState;
 import com.jaspersoft.android.sdk.network.entity.execution.ReportExecutionDescriptor;
 import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Tom Koptel
@@ -40,17 +42,20 @@ import java.util.List;
 abstract class AbstractReportService extends ReportService {
     protected final ExportExecutionApi mExportExecutionApi;
     protected final ReportExecutionApi mReportExecutionApi;
+    protected final ReportOptionsUseCase mReportOptionsUseCase;
     protected final ControlsApi mControlsApi;
     protected final ExportFactory mExportFactory;
     protected final long mDelay;
 
     protected AbstractReportService(ExportExecutionApi exportExecutionApi,
                                     ReportExecutionApi reportExecutionApi,
+                                    ReportOptionsUseCase reportOptionsUseCase,
                                     ControlsApi controlsApi,
                                     ExportFactory exportFactory,
                                     long delay) {
         mExportExecutionApi = exportExecutionApi;
         mReportExecutionApi = reportExecutionApi;
+        mReportOptionsUseCase = reportOptionsUseCase;
         mControlsApi = controlsApi;
         mExportFactory = exportFactory;
         mDelay = delay;
@@ -77,6 +82,31 @@ abstract class AbstractReportService extends ReportService {
     public final List<InputControlState> listControlsValues(@NotNull String reportUri,
                                                             @NotNull List<ReportParameter> parameters) throws ServiceException {
         return mControlsApi.requestControlsValues(reportUri, parameters, true);
+    }
+
+    @NotNull
+    @Override
+    public final Set<ReportOption> listReportOptions(@NotNull String reportUnitUri) throws ServiceException {
+        return mReportOptionsUseCase.requestReportOptionsList(reportUnitUri);
+    }
+
+    @NotNull
+    @Override
+    public final ReportOption createReportOption(@NotNull String reportUri,
+                                           @NotNull String optionLabel,
+                                           @NotNull List<ReportParameter> parameters,
+                                           boolean overwrite) throws ServiceException {
+        return mReportOptionsUseCase.createReportOption(reportUri, optionLabel, parameters, overwrite);
+    }
+
+    @Override
+    public void updateReportOption(@NotNull String reportUri, @NotNull String optionId, @NotNull List<ReportParameter> parameters) throws ServiceException {
+        mReportOptionsUseCase.updateReportOption(reportUri, optionId, parameters);
+    }
+
+    @Override
+    public void deleteReportOption(@NotNull String reportUri, @NotNull String optionId) throws ServiceException {
+        mReportOptionsUseCase.deleteReportOption(reportUri, optionId);
     }
 
     protected abstract ReportExecution buildExecution(String reportUri, String executionId, ReportExecutionOptions criteria);

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/ProxyReportService.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/ProxyReportService.java
@@ -27,12 +27,14 @@ package com.jaspersoft.android.sdk.service.report;
 import com.jaspersoft.android.sdk.network.entity.control.InputControl;
 import com.jaspersoft.android.sdk.network.entity.control.InputControlState;
 import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import com.jaspersoft.android.sdk.service.internal.Preconditions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Tom Koptel
@@ -71,6 +73,43 @@ final class ProxyReportService extends ReportService {
         Preconditions.checkNotNull(reportUri, "Report uri should not be null");
         Preconditions.checkNotNull(parameters, "Parameters should not be null");
         return getDelegate().listControlsValues(reportUri, parameters);
+    }
+
+    @NotNull
+    @Override
+    public Set<ReportOption> listReportOptions(@Nullable String reportUri) throws ServiceException {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        return getDelegate().listReportOptions(reportUri);
+    }
+
+    @NotNull
+    @Override
+    public ReportOption createReportOption(@NotNull String reportUri,
+                                           @NotNull String optionLabel,
+                                           @NotNull List<ReportParameter> parameters,
+                                           boolean overwrite) throws ServiceException {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        Preconditions.checkNotNull(optionLabel, "Option label should not be null");
+        Preconditions.checkNotNull(parameters, "Parameters should not be null");
+
+        return getDelegate().createReportOption(reportUri, optionLabel, parameters, overwrite);
+    }
+
+    @Override
+    public void updateReportOption(@NotNull String reportUri, @NotNull String optionId, @NotNull List<ReportParameter> parameters) throws ServiceException {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        Preconditions.checkNotNull(optionId, "Option id should not be null");
+        Preconditions.checkNotNull(parameters, "Parameters should not be null");
+
+        getDelegate().updateReportOption(reportUri, optionId, parameters);
+    }
+
+    @Override
+    public void deleteReportOption(@NotNull String reportUri, @NotNull String optionId) throws ServiceException {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        Preconditions.checkNotNull(optionId, "Option id should not be null");
+
+        getDelegate().deleteReportOption(reportUri, optionId);
     }
 
     private ReportService getDelegate() throws ServiceException {

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportOptionsUseCase.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportOptionsUseCase.java
@@ -1,0 +1,69 @@
+package com.jaspersoft.android.sdk.service.report;
+
+import com.jaspersoft.android.sdk.network.HttpException;
+import com.jaspersoft.android.sdk.network.ReportOptionRestApi;
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
+import com.jaspersoft.android.sdk.service.exception.ServiceException;
+import com.jaspersoft.android.sdk.service.internal.ServiceExceptionMapper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Tom Koptel
+ * @since 2.0
+ */
+class ReportOptionsUseCase {
+    private final ServiceExceptionMapper mExceptionMapper;
+    private final ReportOptionRestApi mReportOptionRestApi;
+
+    ReportOptionsUseCase(ServiceExceptionMapper exceptionMapper, ReportOptionRestApi reportOptionRestApi) {
+        mExceptionMapper = exceptionMapper;
+        mReportOptionRestApi = reportOptionRestApi;
+    }
+
+    public Set<ReportOption> requestReportOptionsList(String reportUnitUri) throws ServiceException {
+        try {
+            return mReportOptionRestApi.requestReportOptionsList(reportUnitUri);
+        } catch (HttpException e) {
+            throw mExceptionMapper.transform(e);
+        } catch (IOException e) {
+            throw mExceptionMapper.transform(e);
+        }
+    }
+
+    public ReportOption createReportOption(String reportUri,
+                                           String optionLabel,
+                                           List<ReportParameter> parameters,
+                                           boolean overwrite) throws ServiceException {
+        try {
+            return mReportOptionRestApi.createReportOption(reportUri, optionLabel, parameters, overwrite);
+        } catch (HttpException e) {
+            throw mExceptionMapper.transform(e);
+        } catch (IOException e) {
+            throw mExceptionMapper.transform(e);
+        }
+    }
+
+    public void updateReportOption(String reportUri, String optionId, List<ReportParameter> parameters) throws ServiceException {
+        try {
+            mReportOptionRestApi.updateReportOption(reportUri, optionId, parameters);
+        } catch (HttpException e) {
+            throw mExceptionMapper.transform(e);
+        } catch (IOException e) {
+            throw mExceptionMapper.transform(e);
+        }
+    }
+
+    public void deleteReportOption(String reportUri, String optionId) throws ServiceException {
+        try {
+            mReportOptionRestApi.deleteReportOption(reportUri, optionId);
+        } catch (HttpException e) {
+            throw mExceptionMapper.transform(e);
+        } catch (IOException e) {
+            throw mExceptionMapper.transform(e);
+        }
+    }
+}

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportService.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportService.java
@@ -28,6 +28,7 @@ import com.jaspersoft.android.sdk.network.AuthorizedClient;
 import com.jaspersoft.android.sdk.network.entity.control.InputControl;
 import com.jaspersoft.android.sdk.network.entity.control.InputControlState;
 import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import com.jaspersoft.android.sdk.service.internal.DefaultExceptionMapper;
 import com.jaspersoft.android.sdk.service.internal.Preconditions;
@@ -39,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -47,7 +49,8 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class ReportService {
     @NotNull
-    public abstract ReportExecution run(@NotNull String reportUri, @Nullable ReportExecutionOptions execOptions) throws ServiceException;
+    public abstract ReportExecution run(@NotNull String reportUri,
+                                        @Nullable ReportExecutionOptions execOptions) throws ServiceException;
 
     @NotNull
     public abstract List<InputControl> listControls(@NotNull String reportUri) throws ServiceException;
@@ -55,6 +58,22 @@ public abstract class ReportService {
     @NotNull
     public abstract List<InputControlState> listControlsValues(@NotNull String reportUri,
                                                                @NotNull List<ReportParameter> parameters) throws ServiceException;
+
+    @NotNull
+    public abstract Set<ReportOption> listReportOptions(@NotNull String reportUri) throws ServiceException;
+
+    @NotNull
+    public abstract ReportOption createReportOption(@NotNull String reportUri,
+                                                    @NotNull String optionLabel,
+                                                    @NotNull List<ReportParameter> parameters,
+                                                    boolean overwrite) throws ServiceException;
+
+    public abstract void updateReportOption(@NotNull String reportUri,
+                                            @NotNull String optionId,
+                                            @NotNull List<ReportParameter> parameters) throws ServiceException;
+
+    public abstract void deleteReportOption(@NotNull String reportUri,
+                                            @NotNull String optionId) throws ServiceException;
 
     @NotNull
     public static ReportService newService(@NotNull AuthorizedClient client) {
@@ -68,6 +87,7 @@ public abstract class ReportService {
                 client.reportExecutionApi(),
                 client.reportExportApi(),
                 client.inputControlApi(),
+                client.reportOptionsApi(),
                 reportMapper,
                 client.getBaseUrl(),
                 TimeUnit.SECONDS.toMillis(1)

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportService5_5.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportService5_5.java
@@ -31,10 +31,11 @@ package com.jaspersoft.android.sdk.service.report;
 final class ReportService5_5 extends AbstractReportService {
     protected ReportService5_5(ExportExecutionApi exportExecutionApi,
                                ReportExecutionApi reportExecutionApi,
+                               ReportOptionsUseCase reportOptionsUseCase,
                                ControlsApi controlsApi,
                                ExportFactory exportFactory,
                                long delay) {
-        super(exportExecutionApi, reportExecutionApi, controlsApi, exportFactory, delay);
+        super(exportExecutionApi, reportExecutionApi, reportOptionsUseCase, controlsApi, exportFactory, delay);
     }
 
     @Override

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportService5_6Plus.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportService5_6Plus.java
@@ -31,10 +31,11 @@ package com.jaspersoft.android.sdk.service.report;
 final class ReportService5_6Plus extends AbstractReportService {
     protected ReportService5_6Plus(ExportExecutionApi exportExecutionApi,
                                    ReportExecutionApi reportExecutionApi,
+                                   ReportOptionsUseCase reportOptionsUseCase,
                                    ControlsApi controlsApi,
                                    ExportFactory exportFactory,
                                    long delay) {
-        super(exportExecutionApi, reportExecutionApi, controlsApi, exportFactory, delay);
+        super(exportExecutionApi, reportExecutionApi, reportOptionsUseCase, controlsApi, exportFactory, delay);
     }
 
     @Override

--- a/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportServiceFactory.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/service/report/ReportServiceFactory.java
@@ -27,6 +27,7 @@ package com.jaspersoft.android.sdk.service.report;
 import com.jaspersoft.android.sdk.network.InputControlRestApi;
 import com.jaspersoft.android.sdk.network.ReportExecutionRestApi;
 import com.jaspersoft.android.sdk.network.ReportExportRestApi;
+import com.jaspersoft.android.sdk.network.ReportOptionRestApi;
 import com.jaspersoft.android.sdk.service.data.server.ServerInfo;
 import com.jaspersoft.android.sdk.service.data.server.ServerVersion;
 import com.jaspersoft.android.sdk.service.exception.ServiceException;
@@ -43,6 +44,7 @@ class ReportServiceFactory {
     private final ReportExecutionRestApi mReportExecutionRestApi;
     private final ReportExportRestApi mReportExportRestApi;
     private final InputControlRestApi mInputControlRestApi;
+    private final ReportOptionRestApi mReportOptionRestApi;
     private final ServiceExceptionMapper mExceptionMapper;
     private final String mBaseUrl;
     private final long mDelay;
@@ -51,12 +53,15 @@ class ReportServiceFactory {
     ReportServiceFactory(InfoCacheManager cacheManager,
                          ReportExecutionRestApi reportExecutionRestApi,
                          ReportExportRestApi reportExportRestApi,
-                         InputControlRestApi inputControlRestApi, ServiceExceptionMapper exceptionMapper,
+                         InputControlRestApi inputControlRestApi,
+                         ReportOptionRestApi reportOptionRestApi,
+                         ServiceExceptionMapper exceptionMapper,
                          String baseUrl, long delay) {
         mCacheManager = cacheManager;
         mReportExecutionRestApi = reportExecutionRestApi;
         mReportExportRestApi = reportExportRestApi;
         mInputControlRestApi = inputControlRestApi;
+        mReportOptionRestApi = reportOptionRestApi;
         mExceptionMapper = exceptionMapper;
         mBaseUrl = baseUrl;
         mDelay = delay;
@@ -76,10 +81,13 @@ class ReportServiceFactory {
         ExportFactory exportFactory = new ExportFactory(exportExecutionApi, attachmentsFactory);
 
         ControlsApi controlsApi = new ControlsApi(mExceptionMapper, mInputControlRestApi);
+        ReportOptionsUseCase reportOptionsUseCase = new ReportOptionsUseCase(mExceptionMapper, mReportOptionRestApi);
+
         if (version.lessThanOrEquals(ServerVersion.v5_5)) {
             return new ReportService5_5(
                     exportExecutionApi,
                     reportExecutionApi,
+                    reportOptionsUseCase,
                     controlsApi,
                     exportFactory,
                     mDelay);
@@ -87,6 +95,7 @@ class ReportServiceFactory {
             return new ReportService5_6Plus(
                     exportExecutionApi,
                     reportExecutionApi,
+                    reportOptionsUseCase,
                     controlsApi,
                     exportFactory,
                     mDelay);

--- a/core/src/test/java/com/jaspersoft/android/sdk/network/ReportOptionRestApiTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/network/ReportOptionRestApiTest.java
@@ -24,6 +24,7 @@
 
 package com.jaspersoft.android.sdk.network;
 
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
 import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.test.MockResponseFactory;
 import com.jaspersoft.android.sdk.test.WebMockRule;
@@ -39,10 +40,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import retrofit.Retrofit;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -55,6 +53,12 @@ import static org.hamcrest.core.IsNot.not;
  */
 @SuppressWarnings("unchecked")
 public class ReportOptionRestApiTest {
+
+    private final static List<ReportParameter> REPORT_PARAMS  =
+            Collections.singletonList(
+                    new ReportParameter("sales_fact_ALL__store_sales_2013_1", Collections.singleton("19"))
+            );
+
     @Rule
     public final WebMockRule mWebMockRule = new WebMockRule();
     @Rule
@@ -88,20 +92,20 @@ public class ReportOptionRestApiTest {
     public void createReportOptionShouldNotAllowNullReportUri() throws Exception {
         mExpectedException.expect(NullPointerException.class);
         mExpectedException.expectMessage("Report uri should not be null");
-        restApiUnderTest.createReportOption(null, "label", Collections.EMPTY_MAP, false);
+        restApiUnderTest.createReportOption(null, "label", REPORT_PARAMS, false);
     }
 
     @Test
     public void createReportOptionShouldNotAllowNullOptionLabel() throws Exception {
         mExpectedException.expect(NullPointerException.class);
         mExpectedException.expectMessage("Option label should not be null");
-        restApiUnderTest.createReportOption("any_id", null, Collections.EMPTY_MAP, false);
+        restApiUnderTest.createReportOption("any_id", null, REPORT_PARAMS, false);
     }
 
     @Test
     public void createReportOptionShouldNotAllowNullControlsValues() throws Exception {
         mExpectedException.expect(NullPointerException.class);
-        mExpectedException.expectMessage("Controls values should not be null");
+        mExpectedException.expectMessage("Parameters values should not be null");
         restApiUnderTest.createReportOption("any_id", "label", null, false);
     }
 
@@ -109,20 +113,20 @@ public class ReportOptionRestApiTest {
     public void updateReportOptionShouldNotAllowNullReportUri() throws Exception {
         mExpectedException.expect(NullPointerException.class);
         mExpectedException.expectMessage("Report uri should not be null");
-        restApiUnderTest.updateReportOption(null, "option_id", Collections.EMPTY_MAP);
+        restApiUnderTest.updateReportOption(null, "option_id", REPORT_PARAMS);
     }
 
     @Test
     public void updateReportOptionShouldNotAllowNullOptionId() throws Exception {
         mExpectedException.expect(NullPointerException.class);
         mExpectedException.expectMessage("Option id should not be null");
-        restApiUnderTest.updateReportOption("any_id", null, Collections.EMPTY_MAP);
+        restApiUnderTest.updateReportOption("any_id", null, REPORT_PARAMS);
     }
 
     @Test
     public void updateReportOptionShouldNotAllowNullControlsValues() throws Exception {
         mExpectedException.expect(NullPointerException.class);
-        mExpectedException.expectMessage("Controls values should not be null");
+        mExpectedException.expectMessage("Parameters values should not be null");
         restApiUnderTest.updateReportOption("any_id", "option_id", null);
     }
 
@@ -157,10 +161,7 @@ public class ReportOptionRestApiTest {
         MockResponse mockResponse = MockResponseFactory.create200().setBody(reportOption.asString());
         mWebMockRule.enqueue(mockResponse);
 
-        Map<String, Set<String>> params = new HashMap<>();
-        params.put("sales_fact_ALL__store_sales_2013_1", Collections.singleton("19"));
-
-        ReportOption reportOption = restApiUnderTest.createReportOption("/any/uri", "my label", params, true);
+        ReportOption reportOption = restApiUnderTest.createReportOption("/any/uri", "my label", REPORT_PARAMS, true);
         assertThat(reportOption.getId(), is("my_label"));
         assertThat(reportOption.getLabel(), is("my label"));
         assertThat(reportOption.getUri(), is("/public/Samples/Reports/my_label"));
@@ -177,7 +178,7 @@ public class ReportOptionRestApiTest {
         Map<String, Set<String>> params = new HashMap<>();
         params.put("sales_fact_ALL__store_sales_2013_1", Collections.singleton("22"));
 
-        restApiUnderTest.updateReportOption("/any/uri", "option_id", params);
+        restApiUnderTest.updateReportOption("/any/uri", "option_id", REPORT_PARAMS);
 
         RecordedRequest request = mWebMockRule.get().takeRequest();
         assertThat(request.getPath(), is("/rest_v2/reports/any/uri/options/option_id"));
@@ -210,7 +211,7 @@ public class ReportOptionRestApiTest {
 
         mWebMockRule.enqueue(MockResponseFactory.create500());
 
-        restApiUnderTest.updateReportOption("any_id", "option_id", Collections.EMPTY_MAP);
+        restApiUnderTest.updateReportOption("any_id", "option_id", REPORT_PARAMS);
     }
 
     @Test

--- a/core/src/test/java/com/jaspersoft/android/sdk/network/ReportParamsMapperTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/network/ReportParamsMapperTest.java
@@ -1,0 +1,27 @@
+package com.jaspersoft.android.sdk.network;
+
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertThat;
+
+
+public class ReportParamsMapperTest {
+    @Test
+    public void testToMap() throws Exception {
+        ReportParameter reportParameter1 = new ReportParameter("a", Collections.singleton("b"));
+        ReportParameter reportParameter2 = new ReportParameter("c", Collections.singleton("d"));
+        Map<String, Set<String>> params = ReportParamsMapper.INSTANCE.toMap(
+                Arrays.asList(reportParameter1, reportParameter2));
+
+        Set<String> values = new HashSet<>();
+        for (Set<String> sets : params.values()) {
+            values.addAll(sets);
+        }
+        assertThat(params.keySet(), hasItems("a", "c"));
+        assertThat(values, hasItems("b", "d"));
+    }
+}

--- a/core/src/test/java/com/jaspersoft/android/sdk/network/entity/report/option/ReportOptionTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/network/entity/report/option/ReportOptionTest.java
@@ -25,14 +25,14 @@
 package com.jaspersoft.android.sdk.network.entity.report.option;
 
 import com.google.gson.annotations.Expose;
-
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
-
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 
 import static com.jaspersoft.android.sdk.test.matcher.HasAnnotation.hasAnnotation;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,4 +55,10 @@ public class ReportOptionTest {
         assertThat(field, hasAnnotation(Expose.class));
     }
 
+    @Test
+    public void testEquals() throws Exception {
+        EqualsVerifier.forClass(ReportOption.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
 }

--- a/core/src/test/java/com/jaspersoft/android/sdk/service/report/AbstractReportServiceTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/service/report/AbstractReportServiceTest.java
@@ -51,11 +51,16 @@ public class AbstractReportServiceTest {
 
     private static final String REPORT_URI = "my/uri";
     private static final String EXEC_ID = "exec_id";
+    private static final String OPTION_LABEL = "label";
+    private static final String OPTION_ID = OPTION_LABEL;
+    private static final List<ReportParameter> REPORT_PARAMETERS = Collections.emptyList();
 
     @Mock
     ExportExecutionApi mExportExecutionApi;
     @Mock
     ReportExecutionApi mReportExecutionApi;
+    @Mock
+    ReportOptionsUseCase mReportOptionsUseCase;
     @Mock
     ControlsApi mControlsApi;
     @Mock
@@ -72,6 +77,7 @@ public class AbstractReportServiceTest {
         reportService = new AbstractReportService(
                 mExportExecutionApi,
                 mReportExecutionApi,
+                mReportOptionsUseCase,
                 mControlsApi,
                 mExportFactory,
                 0) {
@@ -108,5 +114,29 @@ public class AbstractReportServiceTest {
         List<ReportParameter> parameters = Collections.emptyList();
         reportService.listControlsValues(REPORT_URI, parameters);
         verify(mControlsApi).requestControlsValues(REPORT_URI, parameters, true);
+    }
+
+    @Test
+    public void should_request_options() throws Exception {
+        reportService.listReportOptions(REPORT_URI);
+        verify(mReportOptionsUseCase).requestReportOptionsList(REPORT_URI);
+    }
+
+    @Test
+    public void should_create_report_option() throws Exception {
+        reportService.createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+        verify(mReportOptionsUseCase).createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+    }
+
+    @Test
+    public void should_update_report_option() throws Exception {
+        reportService.updateReportOption(REPORT_URI, OPTION_ID, REPORT_PARAMETERS);
+        verify(mReportOptionsUseCase).updateReportOption(REPORT_URI, OPTION_ID, REPORT_PARAMETERS);
+    }
+
+    @Test
+    public void should_delete_report_option() throws Exception {
+        reportService.deleteReportOption(REPORT_URI, OPTION_ID);
+        verify(mReportOptionsUseCase).deleteReportOption(REPORT_URI, OPTION_ID);
     }
 }

--- a/core/src/test/java/com/jaspersoft/android/sdk/service/report/ProxyReportServiceTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/service/report/ProxyReportServiceTest.java
@@ -20,6 +20,9 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class ProxyReportServiceTest {
 
     private static final String REPORT_URI = "/my/uri";
+    private static final String OPTION_LABEL = "label";
+    private static final String OPTION_ID = OPTION_LABEL;
+    private static final List<ReportParameter> REPORT_PARAMETERS = Collections.emptyList();
 
     @Mock
     ReportServiceFactory mReportServiceFactory;
@@ -60,6 +63,26 @@ public class ProxyReportServiceTest {
     }
 
     @Test
+    public void should_delegate_list_report_options_call() throws Exception {
+        proxyReportService.listReportOptions(REPORT_URI);
+        verify(mReportServiceFactory).newService();
+        verify(mReportService).listReportOptions(eq(REPORT_URI));
+    }
+
+    @Test
+    public void should_delegate_create_report_option_call() throws Exception {
+        proxyReportService.createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+        verify(mReportServiceFactory).newService();
+        verify(mReportService).createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+    }
+   @Test
+    public void should_delegate_update_report_option_call() throws Exception {
+        proxyReportService.updateReportOption(REPORT_URI, OPTION_ID, REPORT_PARAMETERS);
+        verify(mReportServiceFactory).newService();
+        verify(mReportService).updateReportOption(REPORT_URI, OPTION_ID, REPORT_PARAMETERS);
+    }
+
+    @Test
     public void should_not_list_controls_with_null_uri() throws Exception {
         expected.expect(NullPointerException.class);
         expected.expectMessage("Report uri should not be null");
@@ -78,6 +101,69 @@ public class ProxyReportServiceTest {
         expected.expect(NullPointerException.class);
         expected.expectMessage("Report uri should not be null");
         proxyReportService.listControlsValues(null, Collections.<ReportParameter>emptyList());
+    }
+
+    @Test
+    public void should_not_list_report_options_with_null_uri() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Report uri should not be null");
+        proxyReportService.listReportOptions(null);
+    }
+
+    @Test
+    public void should_not_create_report_option_with_null_uri() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Report uri should not be null");
+        proxyReportService.createReportOption(null, OPTION_LABEL, REPORT_PARAMETERS, true);
+    }
+
+    @Test
+    public void should_not_create_report_option_with_null_option_label() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Option label should not be null");
+        proxyReportService.createReportOption(REPORT_URI, null, REPORT_PARAMETERS, true);
+    }
+
+    @Test
+    public void should_not_create_report_option_with_null_parameters() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Parameters should not be null");
+        proxyReportService.createReportOption(REPORT_URI, OPTION_LABEL, null, true);
+    }
+
+    @Test
+    public void should_not_update_report_option_with_null_uri() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Report uri should not be null");
+        proxyReportService.updateReportOption(null, OPTION_ID, REPORT_PARAMETERS);
+    }
+
+    @Test
+    public void should_not_update_report_option_with_null_option_id() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Option id should not be null");
+        proxyReportService.updateReportOption(REPORT_URI, null, REPORT_PARAMETERS);
+    }
+
+    @Test
+    public void should_not_update_report_option_with_null_parameters() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Parameters should not be null");
+        proxyReportService.updateReportOption(REPORT_URI, OPTION_ID, null);
+    }
+
+    @Test
+    public void should_not_delete_report_option_with_null_uri() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Report uri should not be null");
+        proxyReportService.deleteReportOption(null, OPTION_ID);
+    }
+
+    @Test
+    public void should_not_delete_report_option_with_null_option_id() throws Exception {
+        expected.expect(NullPointerException.class);
+        expected.expectMessage("Option id should not be null");
+        proxyReportService.deleteReportOption(REPORT_URI, null);
     }
 
     @Test

--- a/core/src/test/java/com/jaspersoft/android/sdk/service/report/ReportOptionsUseCaseTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/service/report/ReportOptionsUseCaseTest.java
@@ -1,0 +1,177 @@
+package com.jaspersoft.android.sdk.service.report;
+
+import com.jaspersoft.android.sdk.network.HttpException;
+import com.jaspersoft.android.sdk.network.ReportOptionRestApi;
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.service.exception.ServiceException;
+import com.jaspersoft.android.sdk.service.internal.ServiceExceptionMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.fail;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ReportOptionsUseCaseTest {
+    private static final String REPORT_URI = "/my/uri";
+    private static final String OPTION_LABEL = "label";
+    private static final String OPTION_ID = OPTION_LABEL;
+    private static final List<ReportParameter> REPORT_PARAMETERS = Collections.emptyList();
+
+    @Mock
+    ServiceExceptionMapper mExceptionMapper;
+    @Mock
+    ReportOptionRestApi mReportOptionRestApi;
+
+    @Mock
+    IOException mIOException;
+    @Mock
+    HttpException mHttpException;
+    @Mock
+    ServiceException mServiceException;
+
+    private ReportOptionsUseCase reportOptionsUseCase;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        setupMocks();
+        reportOptionsUseCase = new ReportOptionsUseCase(mExceptionMapper, mReportOptionRestApi);
+    }
+
+    @Test
+    public void should_list_report_options() throws Exception {
+        reportOptionsUseCase.requestReportOptionsList(REPORT_URI);
+        verify(mReportOptionRestApi).requestReportOptionsList(REPORT_URI);
+    }
+
+    @Test
+    public void list_report_options_adapts_io_exception() throws Exception {
+        when(mReportOptionRestApi.requestReportOptionsList(anyString())).thenThrow(mIOException);
+        try {
+            reportOptionsUseCase.requestReportOptionsList(REPORT_URI);
+            fail("Should adapt IO exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mIOException);
+        }
+    }
+
+    @Test
+    public void list_report_options_adapts_http_exception() throws Exception {
+        when(mReportOptionRestApi.requestReportOptionsList(anyString())).thenThrow(mHttpException);
+
+        try {
+            reportOptionsUseCase.requestReportOptionsList(REPORT_URI);
+            fail("Should adapt HTTP exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mHttpException);
+        }
+    }
+
+    @Test
+    public void should_create_report_option() throws Exception {
+        reportOptionsUseCase.createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+        verify(mReportOptionRestApi).createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+    }
+
+
+    @Test
+    public void should_update_report_option() throws Exception {
+        reportOptionsUseCase.updateReportOption(REPORT_URI, OPTION_ID, REPORT_PARAMETERS);
+        verify(mReportOptionRestApi).updateReportOption(REPORT_URI, OPTION_ID, REPORT_PARAMETERS);
+    }
+
+    @Test
+    public void should_delete_report_option() throws Exception {
+        reportOptionsUseCase.deleteReportOption(REPORT_URI, OPTION_LABEL);
+        verify(mReportOptionRestApi).deleteReportOption(REPORT_URI, OPTION_ID);
+    }
+
+    @Test
+    public void create_report_option_adapts_io_exception() throws Exception {
+        when(mReportOptionRestApi.createReportOption(anyString(),
+                anyString(), anyListOf(ReportParameter.class), anyBoolean())).thenThrow(mIOException);
+        try {
+            reportOptionsUseCase.createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+            fail("Should adapt IO exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mIOException);
+        }
+    }
+
+    @Test
+    public void create_report_option_adapts_http_exception() throws Exception {
+        when(mReportOptionRestApi.createReportOption(anyString(),
+                anyString(), anyListOf(ReportParameter.class), anyBoolean())).thenThrow(mHttpException);
+
+        try {
+            reportOptionsUseCase.createReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS, true);
+            fail("Should adapt HTTP exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mHttpException);
+        }
+    }
+
+
+
+    @Test
+    public void update_report_option_adapts_io_exception() throws Exception {
+        doThrow(mIOException).when(mReportOptionRestApi).updateReportOption(anyString(),
+                anyString(), anyListOf(ReportParameter.class));
+        try {
+            reportOptionsUseCase.updateReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS);
+            fail("Should adapt IO exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mIOException);
+        }
+    }
+
+    @Test
+    public void update_report_option_adapts_http_exception() throws Exception {
+        doThrow(mHttpException).when(mReportOptionRestApi).updateReportOption(anyString(),
+                anyString(), anyListOf(ReportParameter.class));
+        try {
+            reportOptionsUseCase.updateReportOption(REPORT_URI, OPTION_LABEL, REPORT_PARAMETERS);
+            fail("Should adapt HTTP exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mHttpException);
+        }
+    }
+
+    @Test
+    public void delete_report_option_adapts_io_exception() throws Exception {
+        doThrow(mIOException).when(mReportOptionRestApi).deleteReportOption(anyString(), anyString());
+
+        try {
+            reportOptionsUseCase.deleteReportOption(REPORT_URI, OPTION_LABEL);
+            fail("Should adapt IO exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mIOException);
+        }
+    }
+
+    @Test
+    public void delete_report_option_adapts_http_exception() throws Exception {
+        doThrow(mHttpException).when(mReportOptionRestApi).deleteReportOption(anyString(), anyString());
+
+        try {
+            reportOptionsUseCase.deleteReportOption(REPORT_URI, OPTION_LABEL);
+            fail("Should adapt HTTP exception");
+        } catch (ServiceException ex) {
+            verify(mExceptionMapper).transform(mHttpException);
+        }
+    }
+
+    private void setupMocks() {
+        when(mExceptionMapper.transform(any(HttpException.class))).thenReturn(mServiceException);
+        when(mExceptionMapper.transform(any(IOException.class))).thenReturn(mServiceException);
+    }
+}

--- a/core/src/test/java/com/jaspersoft/android/sdk/test/integration/api/ReportOptionRestApiTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/test/integration/api/ReportOptionRestApiTest.java
@@ -26,14 +26,12 @@ package com.jaspersoft.android.sdk.test.integration.api;
 
 import com.jaspersoft.android.sdk.network.AuthorizedClient;
 import com.jaspersoft.android.sdk.network.ReportOptionRestApi;
+import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
 import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import org.junit.Before;
 import org.junit.Ignore;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -47,13 +45,10 @@ import static org.hamcrest.core.IsNot.not;
 public class ReportOptionRestApiTest {
 
     private static final String REPORT_URI = "/public/Samples/Reports/1._Geographic_Results_by_Segment_Report";
-    public static final Map<String, Set<String>> CONTROL_PARAMETERS = new HashMap<>();
-
-    static {
-        Set<String> values = new HashSet<>();
-        values.add("19");
-        CONTROL_PARAMETERS.put("sales_fact_ALL__store_sales_2013_1", values);
-    }
+    private final static List<ReportParameter> REPORT_PARAMS  =
+            Collections.singletonList(
+                    new ReportParameter("sales_fact_ALL__store_sales_2013_1", Collections.singleton("19"))
+            );
 
     private final LazyClient mLazyClient = new LazyClient(JrsMetadata.createMobileDemo2());
     private ReportOptionRestApi apiUnderTest;
@@ -76,10 +71,10 @@ public class ReportOptionRestApiTest {
     // TODO: fix this by providing proper integration tests
     @Ignore
     public void apiSupportsCrudForReportOption() throws Exception {
-        ReportOption response = apiUnderTest.createReportOption(REPORT_URI, "label", CONTROL_PARAMETERS, true);
+        ReportOption response = apiUnderTest.createReportOption(REPORT_URI, "label", REPORT_PARAMS, true);
         assertThat(response.getLabel(), is("label"));
 
-        apiUnderTest.updateReportOption(REPORT_URI, response.getId(), CONTROL_PARAMETERS);
+        apiUnderTest.updateReportOption(REPORT_URI, response.getId(), REPORT_PARAMS);
 
         apiUnderTest.deleteReportOption(REPORT_URI, response.getId());
     }

--- a/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/report/RxReportService.java
+++ b/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/report/RxReportService.java
@@ -28,6 +28,7 @@ import com.jaspersoft.android.sdk.network.AuthorizedClient;
 import com.jaspersoft.android.sdk.network.entity.control.InputControl;
 import com.jaspersoft.android.sdk.network.entity.control.InputControlState;
 import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.service.internal.Preconditions;
 import com.jaspersoft.android.sdk.service.report.ReportExecutionOptions;
 import com.jaspersoft.android.sdk.service.report.ReportService;
@@ -36,6 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import rx.Observable;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Tom Koptel
@@ -50,6 +52,24 @@ public abstract class RxReportService {
 
     @NotNull
     public abstract Observable<List<InputControlState>> listControlsValues(@NotNull String reportUri, @NotNull List<ReportParameter> parameters);
+
+    @NotNull
+    public abstract Observable<Set<ReportOption>> listReportOptions(@NotNull String reportUri);
+
+    @NotNull
+    public abstract Observable<ReportOption> createReportOption(@NotNull String reportUri,
+                                                                @NotNull String optionLabel,
+                                                                @NotNull List<ReportParameter> parameters,
+                                                                boolean overwrite);
+
+    @NotNull
+    public abstract Observable<Void> updateReportOption(@NotNull String reportUri,
+                                                        @NotNull String optionId,
+                                                        @NotNull List<ReportParameter> parameters);
+
+    @NotNull
+    public abstract Observable<Void> deleteReportOption(@NotNull String reportUri,
+                                                       @NotNull String optionId);
 
     @NotNull
     public static RxReportService newService(@NotNull AuthorizedClient authorizedClient) {

--- a/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/report/RxReportServiceImpl.java
+++ b/rx/src/main/java/com/jaspersoft/android/sdk/service/rx/report/RxReportServiceImpl.java
@@ -27,6 +27,7 @@ package com.jaspersoft.android.sdk.service.rx.report;
 import com.jaspersoft.android.sdk.network.entity.control.InputControl;
 import com.jaspersoft.android.sdk.network.entity.control.InputControlState;
 import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import com.jaspersoft.android.sdk.service.internal.Preconditions;
 import com.jaspersoft.android.sdk.service.report.ReportExecution;
@@ -39,6 +40,7 @@ import rx.Observable;
 import rx.functions.Func0;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Tom Koptel
@@ -105,6 +107,86 @@ final class RxReportServiceImpl extends RxReportService {
                 } catch (ServiceException e) {
                     return Observable.error(e);
                 }
+            }
+        });
+    }
+
+    @NotNull
+    @Override
+    public Observable<Set<ReportOption>> listReportOptions(@NotNull final String reportUri) {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+
+        return Observable.defer(new Func0<Observable<Set<ReportOption>>>() {
+            @Override
+            public Observable<Set<ReportOption>> call() {
+                try {
+                    Set<ReportOption> reportOptions = mSyncDelegate.listReportOptions(reportUri);
+                    return Observable.just(reportOptions);
+                } catch (ServiceException e) {
+                    return Observable.error(e);
+                }
+            }
+        });
+    }
+
+    @NotNull
+    @Override
+    public Observable<ReportOption> createReportOption(@NotNull final String reportUri,
+                                                       @NotNull final String optionLabel,
+                                                       @NotNull final List<ReportParameter> parameters,
+                                                       final boolean overwrite) {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        Preconditions.checkNotNull(optionLabel, "Option label should not be null");
+        Preconditions.checkNotNull(parameters, "Parameters should not be null");
+
+        return Observable.defer(new Func0<Observable<ReportOption>>() {
+            @Override
+            public Observable<ReportOption> call() {
+                try {
+                    ReportOption reportOption = mSyncDelegate.createReportOption(reportUri, optionLabel, parameters, overwrite);
+                    return Observable.just(reportOption);
+                } catch (ServiceException e) {
+                    return Observable.error(e);
+                }
+            }
+        });
+    }
+
+    @NotNull
+    @Override
+    public Observable<Void> updateReportOption(@NotNull final String reportUri, @NotNull final String optionId, @NotNull final List<ReportParameter> parameters) {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        Preconditions.checkNotNull(optionId, "Option id should not be null");
+        Preconditions.checkNotNull(parameters, "Parameters should not be null");
+
+        return Observable.defer(new Func0<Observable<Void>>() {
+            @Override
+            public Observable<Void> call() {
+                try {
+                    mSyncDelegate.updateReportOption(reportUri, optionId, parameters);
+                } catch (ServiceException e) {
+                    return Observable.error(e);
+                }
+                return Observable.just(null);
+            }
+        });
+    }
+
+    @NotNull
+    @Override
+    public Observable<Void> deleteReportOption(@NotNull final String reportUri, @NotNull final String optionId) throws ServiceException {
+        Preconditions.checkNotNull(reportUri, "Report uri should not be null");
+        Preconditions.checkNotNull(optionId, "Option id should not be null");
+
+        return Observable.defer(new Func0<Observable<Void>>() {
+            @Override
+            public Observable<Void> call() {
+                try {
+                    mSyncDelegate.deleteReportOption(reportUri, optionId);
+                } catch (ServiceException e) {
+                    return Observable.error(e);
+                }
+                return Observable.just(null);
             }
         });
     }

--- a/rx/src/test/java/com/jaspersoft/android/sdk/service/rx/report/RxReportServiceTest.java
+++ b/rx/src/test/java/com/jaspersoft/android/sdk/service/rx/report/RxReportServiceTest.java
@@ -28,6 +28,7 @@ import com.jaspersoft.android.sdk.network.AuthorizedClient;
 import com.jaspersoft.android.sdk.network.entity.control.InputControl;
 import com.jaspersoft.android.sdk.network.entity.control.InputControlState;
 import com.jaspersoft.android.sdk.network.entity.report.ReportParameter;
+import com.jaspersoft.android.sdk.network.entity.report.option.ReportOption;
 import com.jaspersoft.android.sdk.service.exception.ServiceException;
 import com.jaspersoft.android.sdk.service.report.ReportExecution;
 import com.jaspersoft.android.sdk.service.report.ReportExecutionOptions;
@@ -41,13 +42,14 @@ import rx.observers.TestSubscriber;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -56,6 +58,8 @@ public class RxReportServiceTest {
     private static final String REPORT_URI = "my/uri";
     private static final ReportExecutionOptions OPTIONS = ReportExecutionOptions.builder().build();
     private static final List<ReportParameter> PARAMS = Collections.emptyList();
+    private static final String OPTION_LABEL = "label";
+    private static final String OPTION_ID = OPTION_LABEL;
 
     @Mock
     ReportService mSyncDelegate;
@@ -63,6 +67,8 @@ public class RxReportServiceTest {
     ReportExecution mReportExecution;
     @Mock
     ServiceException mServiceException;
+
+    private ReportOption fakeReportOption = new ReportOption();
 
     @Mock
     AuthorizedClient mAuthorizedClient;
@@ -175,6 +181,114 @@ public class RxReportServiceTest {
         test.assertValueCount(1);
 
         verify(mSyncDelegate).listControlsValues(REPORT_URI, PARAMS);
+    }
+
+    @Test
+    public void should_delegate_service_exception_to_subscription_on_list_report_options() throws Exception {
+        when(mSyncDelegate.listReportOptions(anyString())).thenThrow(mServiceException);
+
+        TestSubscriber<Set<ReportOption>> test = TestSubscriber.create();
+        rxReportService.listReportOptions(REPORT_URI).subscribe(test);
+
+        test.assertError(mServiceException);
+        test.assertNotCompleted();
+
+        verify(mSyncDelegate).listReportOptions(REPORT_URI);
+    }
+
+    @Test
+    public void should_execute_delegate_as_observable_on_list_report_options() throws Exception {
+        when(mSyncDelegate.listReportOptions(anyString()))
+                .thenReturn(Collections.<ReportOption>emptySet());
+
+        TestSubscriber<Set<ReportOption>> test = TestSubscriber.create();
+        rxReportService.listReportOptions(REPORT_URI).subscribe(test);
+
+        test.assertCompleted();
+        test.assertNoErrors();
+        test.assertValueCount(1);
+
+        verify(mSyncDelegate).listReportOptions(REPORT_URI);
+    }
+
+    @Test
+    public void should_delegate_service_exception_to_subscription_on_create_report_option() throws Exception {
+        when(mSyncDelegate.createReportOption(anyString(), anyString(), anyListOf(ReportParameter.class), anyBoolean()))
+                .thenThrow(mServiceException);
+
+        TestSubscriber<ReportOption> test = TestSubscriber.create();
+        rxReportService.createReportOption(REPORT_URI, OPTION_LABEL, PARAMS, true).subscribe(test);
+
+        test.assertError(mServiceException);
+        test.assertNotCompleted();
+
+        verify(mSyncDelegate).createReportOption(REPORT_URI, OPTION_LABEL, PARAMS, true);
+    }
+
+    @Test
+    public void should_execute_delegate_as_observable_on_create_report_option() throws Exception {
+        when(mSyncDelegate.createReportOption(anyString(), anyString(), anyListOf(ReportParameter.class), anyBoolean()))
+                .thenReturn(fakeReportOption);
+
+        TestSubscriber<ReportOption> test = TestSubscriber.create();
+        rxReportService.createReportOption(REPORT_URI, OPTION_LABEL, PARAMS, true).subscribe(test);
+
+        test.assertCompleted();
+        test.assertNoErrors();
+        test.assertValueCount(1);
+
+        verify(mSyncDelegate).createReportOption(REPORT_URI, OPTION_LABEL, PARAMS, true);
+    }
+
+    @Test
+    public void should_delegate_service_exception_to_subscription_on_update_report_option() throws Exception {
+        doThrow(mServiceException).when(mSyncDelegate).updateReportOption(anyString(),
+                anyString(), anyListOf(ReportParameter.class));
+
+        TestSubscriber<Void> test = TestSubscriber.create();
+        rxReportService.updateReportOption(REPORT_URI, OPTION_ID, PARAMS).subscribe(test);
+
+        test.assertError(mServiceException);
+        test.assertNotCompleted();
+
+        verify(mSyncDelegate).updateReportOption(REPORT_URI, OPTION_ID, PARAMS);
+    }
+
+    @Test
+    public void should_execute_delegate_as_observable_on_update_report_option() throws Exception {
+        TestSubscriber<Void> test = TestSubscriber.create();
+        rxReportService.updateReportOption(REPORT_URI, OPTION_ID, PARAMS).subscribe(test);
+
+        test.assertCompleted();
+        test.assertNoErrors();
+        test.assertValueCount(1);
+
+        verify(mSyncDelegate).updateReportOption(REPORT_URI, OPTION_ID, PARAMS);
+    }
+
+    @Test
+    public void should_delegate_service_exception_to_subscription_on_delete_report_option() throws Exception {
+        doThrow(mServiceException).when(mSyncDelegate).deleteReportOption(anyString(), anyString());
+
+        TestSubscriber<Void> test = TestSubscriber.create();
+        rxReportService.deleteReportOption(REPORT_URI, OPTION_ID).subscribe(test);
+
+        test.assertError(mServiceException);
+        test.assertNotCompleted();
+
+        verify(mSyncDelegate).deleteReportOption(REPORT_URI, OPTION_ID);
+    }
+
+    @Test
+    public void should_execute_delegate_as_observable_on_delete_report_option() throws Exception {
+        TestSubscriber<Void> test = TestSubscriber.create();
+        rxReportService.deleteReportOption(REPORT_URI, OPTION_ID).subscribe(test);
+
+        test.assertCompleted();
+        test.assertNoErrors();
+        test.assertValueCount(1);
+
+        verify(mSyncDelegate).deleteReportOption(REPORT_URI, OPTION_ID);
     }
 
     @Test


### PR DESCRIPTION
``` java
AuthorizedClient client;
String reportUri = "";
String optionId = "";
String optionLabel = "";
List<ReportParameter> parameters = Collections.emptyList();

ReportService reportService = ReportService.newService(client);
try {
    reportService.listReportOptions(reportUri);
} catch (ServiceException e) {
    e.printStackTrace();
}
try {
    reportService.createReportOption(reportUri, optionLabel, parameters, true);
} catch (ServiceException e) {
    e.printStackTrace();
}
try {
    reportService.updateReportOption(reportUri, optionId, parameters);
} catch (ServiceException e) {
    e.printStackTrace();
}
try {
    reportService.deleteReportOption(reportUri, optionId);
} catch (ServiceException e) {
    e.printStackTrace();
}
RxReportService rxReportService = RxReportService.newService(client);
rxReportService.listReportOptions(reportUri).subscribe();
rxReportService.createReportOption(reportUri, optionLabel, parameters, true).subscribe();
rxReportService.updateReportOption(reportUri, optionId, parameters).subscribe();
rxReportService.deleteReportOption(reportUri, optionId).subscribe();
```
