### PR TITLE
Fix: Get encryption always responds with empty key on error

### DIFF
--- a/core/src/main/java/com/jaspersoft/android/sdk/network/AuthRestApi.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/AuthRestApi.java
@@ -114,8 +114,13 @@ class AuthRestApi {
                 .get()
                 .build();
         try {
-            Response response = mNetworkClient.makeCall(request2);
-            return mNetworkClient.deserializeJson(response, EncryptionKey.class);
+            Response response = mNetworkClient.makeRawCall(request2);
+            int code = response.code();
+            if (code >= 200 && code < 300) {
+                return mNetworkClient.deserializeJson(response, EncryptionKey.class);
+            } else {
+                return EncryptionKey.empty();
+            }
         } catch (JsonSyntaxException ex) {
             /**
              * This possible when security option is disabled on JRS side.

--- a/core/src/main/java/com/jaspersoft/android/sdk/network/NetworkClient.java
+++ b/core/src/main/java/com/jaspersoft/android/sdk/network/NetworkClient.java
@@ -67,6 +67,11 @@ class NetworkClient {
         return new String(response.body().bytes());
     }
 
+    public Response makeRawCall(Request request) throws IOException {
+        com.squareup.okhttp.Call call1 = mClient.newCall(request);
+        return call1.execute();
+    }
+
     public Response makeCall(Request request) throws IOException, HttpException {
         com.squareup.okhttp.Call call1 = mClient.newCall(request);
         Response response = call1.execute();

--- a/core/src/test/java/com/jaspersoft/android/sdk/network/AuthRestApiTest.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/network/AuthRestApiTest.java
@@ -130,4 +130,21 @@ public class AuthRestApiTest {
         EncryptionKey keyResponse = apiUnderTest.requestEncryptionMetadata();
         assertThat(keyResponse.isAvailable(), is(false));
     }
+
+    @Test
+    public void shouldReturnEmptyEncryptionKeyIfApiReturns401Error() throws Exception {
+        MockResponse anonymousCookie = MockResponseFactory.create200()
+                .setBody("6.1")
+                .addHeader("Set-Cookie", "cookie1=12");
+
+        String malformedJson = "{Error: Key generation is off}";
+        MockResponse encryptionKey = MockResponseFactory.create401()
+                .setBody(malformedJson);
+
+        mWebMockRule.enqueue(anonymousCookie);
+        mWebMockRule.enqueue(encryptionKey);
+
+        EncryptionKey keyResponse = apiUnderTest.requestEncryptionMetadata();
+        assertThat(keyResponse.isAvailable(), is(false));
+    }
 }

--- a/core/src/test/java/com/jaspersoft/android/sdk/test/MockResponseFactory.java
+++ b/core/src/test/java/com/jaspersoft/android/sdk/test/MockResponseFactory.java
@@ -53,4 +53,9 @@ public final class MockResponseFactory {
         return new MockResponse()
                 .setStatus("HTTP/1.1 302 Found");
     }
+
+    public static MockResponse create401() {
+        return new MockResponse()
+                .setStatus("HTTP/1.1 401 Unauthorized");
+    }
 }


### PR DESCRIPTION
Jira issue [JM-2446](http://jira.jaspersoft.com/browse/JM-2446)
